### PR TITLE
Commands for installing libraries globally

### DIFF
--- a/README.org
+++ b/README.org
@@ -43,7 +43,10 @@ feedback are appreciated.
 
 ** Usage
 
-   Currently, dependencies are only installed project local.
+   This section covers using Qi for a project. To see other, more
+   general, Qi commands and installing libraries globally see the API
+   section.
+
    The only requirement to installing a systems dependencies with Qi,
    is a =qi.yaml=.
 
@@ -84,6 +87,69 @@ feedback are appreciated.
    your =qi.yaml=.
 
 
+** API
+   Qi's API is composed of a few commands, documented below:
+
+*** Hello
+   Prints some information about Qi to *standard-output*. If this
+   prints, Qi is installed correctly.
+
+   #+BEGIN_SRC lisp
+   (qi:hello)
+   #+END_SRC
+
+*** Install
+   Installs a system and it's dependencies. All dependencies are
+   installed local to the system directory in =.dependencies/=.
+
+   - For any dependencies that are not already available, Qi will try to
+     download them from the Manifest. If all else fails, it will print
+     to *standard-output* what packages could not be installed.
+
+   #+BEGIN_SRC lisp
+   (qi:install :system)
+   #+END_SRC
+
+*** Install Global
+   Installs a system to the global package directory. The system
+   should be from the Manifest. The system is made available in the
+   current session.
+
+   #+BEGIN_SRC lisp
+   (qi:install-global :system &optional version)
+   #+END_SRC
+
+   /To make a global system available at any time, you can use/
+   /(qi:up :system)/
+
+*** Up
+   ASDF load's a system to be available in the current session.
+
+   #+BEGIN_SRC lisp
+   (qi:up :system)
+   #+END_SRC
+
+   /This is the equivalient of running (asdf:load-system :system)/
+
+*** Coming Soon
+
+   *Not implemented* =(qi:new ...)=
+
+   Generate a new project scaffold.
+
+   *Not implemented* =(qi:setup ...)=
+
+   Generate a qi.yaml for an existing project.
+
+   *Not implemented* =(qi:update-manifest ...)=
+
+   Update the Qi manifest to get access to new packages and updates.
+
+   *Not implemented* =(qi:publish ...)=
+
+   Publish a new package to the Qi Manifest
+
+
 ** Manifest
    The [[https://github.com/CodyReichert/qi/blob/master/manifest/manifest.lisp][Qi Manifest]] is a list of known packages - which makes it easy
    to simply install packages by their name. Qi's Manifest was
@@ -102,45 +168,6 @@ feedback are appreciated.
     area. Ideally, we have =recipes/= that contains the information
     about each Qi package. That way a new recipe can be added and the
     Maniest can be updated.
-
-
-** API
-   Qi's API is composed of a few commands, documented below:
-
-   =(qi:hello)=
-
-   Prints some information about Qi to *standard-output*. If this
-   prints, Qi is installed correctly.
-
-   =(qi:install :system-name)=
-
-   Installs a system and transitive dependencies. All dependencies are
-   installed local to the system in =.dependencies/=.
-
-   - Any dependencies that are not already available, Qi will try to
-     download them from the Manifest. If all else fails, it will print
-     to *standard-output* what packages could not be installed.
-
-
-   *Not implemented* =(qi:new ...)=
-
-   Generate a new project scaffold.
-
-   *Not implemented* =(qi:setup ...)=
-
-   Generate a qi.yaml for an existing project.
-
-   *Not implemented* =(qi:install-global ...)=
-
-   Install a system globally.
-
-   *Not implemented* =(qi:update-manifest ...)=
-
-   Update the Qi manifest to get access to new packages and updates.
-
-   *Not implemented* =(qi:publish ...)=
-
-   Publish a new package to the Qi Manifest
 
 
 ** CLI

--- a/manifest/manifest.lisp
+++ b/manifest/manifest.lisp
@@ -68,7 +68,7 @@
     :LOCATIONS (("latest" . "xmlutils")))
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "xmls"
-    :VC "https"
+    :VC "http"
     :LOCATIONS (("latest"
                  . "http://common-lisp.net/project/xmls/xmls-1.7.tgz")))
  #S(QI.MANIFEST::MANIFEST-PACKAGE
@@ -256,7 +256,7 @@
                  . "https://github.com/scymtym/utilities.binary-dump.git")))
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "usocket"
-    :VC "https"
+    :VC "http"
     :LOCATIONS (("latest"
                  . "http://common-lisp.net/project/usocket/releases/usocket-latest.tar.gz")))
  #S(QI.MANIFEST::MANIFEST-PACKAGE
@@ -313,7 +313,7 @@
     :LOCATIONS (("latest" . "umlisp-orf")))
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "uiop"
-    :VC "https"
+    :VC "http"
     :LOCATIONS (("latest"
                  . "http://common-lisp.net/project/asdf/archives/uiop.tar.gz")))
  #S(QI.MANIFEST::MANIFEST-PACKAGE
@@ -710,7 +710,7 @@
                  . "http://common-lisp.net/project/stefil/darcs/stefil")))
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "static-vectors"
-    :VC "https"
+    :VC "http"
     :LOCATIONS (("latest"
                  . "https://github.com/sionescu/static-vectors/archive/v1.6.tar.gz")))
  #S(QI.MANIFEST::MANIFEST-PACKAGE
@@ -731,7 +731,7 @@
     :LOCATIONS (("latest" . "git://github.com/tlh/sqnc.git")))
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "split-sequence"
-    :VC "https"
+    :VC "http"
     :LOCATIONS (("latest"
                  . "https://github.com/sharplispers/split-sequence/archive/v1.2.tar.gz")))
  #S(QI.MANIFEST::MANIFEST-PACKAGE
@@ -799,7 +799,7 @@
     :LOCATIONS (("latest" . "https://github.com/aarvid/SmackJack")))
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "slime"
-    :VC "https"
+    :VC "http"
     :LOCATIONS (("latest"
                  . "https://common-lisp.net/project/slime/slime_latest.tar.gz")))
  #S(QI.MANIFEST::MANIFEST-PACKAGE
@@ -1119,7 +1119,7 @@
     :LOCATIONS (("latest" . "git://github.com/WarrenWilkinson/read-csv.git")))
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "rcl"
-    :VC "https"
+    :VC "http"
     :LOCATIONS (("latest" . "https://common-lisp.net/project/rcl/rcl.tar.gz")))
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "ratify"
@@ -1481,7 +1481,7 @@
     :LOCATIONS (("latest" . "git://github.com/VincentToups/parseltongue.git")))
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "parse-number"
-    :VC "https"
+    :VC "http"
     :LOCATIONS (("latest"
                  . "https://github.com/sharplispers/parse-number/archive/v1.4.tar.gz")))
  #S(QI.MANIFEST::MANIFEST-PACKAGE
@@ -2316,7 +2316,7 @@
     :LOCATIONS (("latest" . "irc-logger")))
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "ip-interfaces"
-    :VC "https"
+    :VC "http"
     :LOCATIONS (("latest"
                  . "https://common-lisp.net/project/ip-interfaces/releases/ip-interfaces-latest.tar.gz")))
  #S(QI.MANIFEST::MANIFEST-PACKAGE
@@ -3232,7 +3232,7 @@
     :LOCATIONS (("latest" . "https://github.com/EuAndreh/defclass-std.git")))
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "declt"
-    :VC "https"
+    :VC "http"
     :LOCATIONS (("latest"
                  . "https://www.lrde.epita.fr/~didier/software/lisp/declt/latest.tar.gz")))
  #S(QI.MANIFEST::MANIFEST-PACKAGE
@@ -4121,7 +4121,7 @@
     :LOCATIONS (("latest" . "git://github.com/tayloj/cl-rdfxml.git")))
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-rcfiles"
-    :VC "https"
+    :VC "http"
     :LOCATIONS (("latest"
                  . "https://www.lrde.epita.fr/~didier/software/lisp/cl-rcfiles.tar.gz")))
  #S(QI.MANIFEST::MANIFEST-PACKAGE
@@ -4568,12 +4568,12 @@
     :LOCATIONS (("latest" . "https://github.com/jwiegley/cl-ledger.git")))
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-launch"
-    :VC "https"
+    :VC "http"
     :LOCATIONS (("latest"
                  . "https://common-lisp.net/project/xcvb/cl-launch/cl-launch.tar.gz")))
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-lastfm"
-    :VC "https"
+    :VC "http"
     :LOCATIONS (("latest"
                  . "https://github.com/nlamirault/cl-lastfm/archive/0.2.1.tar.gz")))
  #S(QI.MANIFEST::MANIFEST-PACKAGE
@@ -5061,7 +5061,7 @@
                  . "git://github.com/archimag/cl-closure-template.git")))
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-clon"
-    :VC "https"
+    :VC "http"
     :LOCATIONS (("latest"
                  . "https://www.lrde.epita.fr/~didier/software/lisp/clon/latest.tar.gz")))
  #S(QI.MANIFEST::MANIFEST-PACKAGE
@@ -5315,7 +5315,7 @@
                  . "git://github.com/WarrenWilkinson/changed-stream.git")))
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cffi"
-    :VC "https"
+    :VC "http"
     :LOCATIONS (("latest"
                  . "https://common-lisp.net/project/cffi/releases/cffi_latest.tar.gz")))
  #S(QI.MANIFEST::MANIFEST-PACKAGE
@@ -5416,7 +5416,7 @@
                  . "http://juhaarpi.users.paivola.fi/bourbaki/bourbaki.tar.gz")))
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "bordeaux-threads"
-    :VC "https"
+    :VC "http"
     :LOCATIONS (("latest"
                  . "https://common-lisp.net/project/bordeaux-threads/releases/bordeaux-threads.tar.gz")))
  #S(QI.MANIFEST::MANIFEST-PACKAGE
@@ -5553,7 +5553,7 @@
     :LOCATIONS (("latest" . "https://github.com/eudoxia0/asdf-linguist.git")))
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "asdf-flv"
-    :VC "https"
+    :VC "http"
     :LOCATIONS (("latest"
                  . "https://www.lrde.epita.fr/~didier/software/lisp/asdf-flv/attic/asdf-flv-1.0.tar.gz")))
  #S(QI.MANIFEST::MANIFEST-PACKAGE

--- a/src/paths.lisp
+++ b/src/paths.lisp
@@ -5,14 +5,34 @@
            :+project-name+
            :qi-dir
            :tar-dir
-           :package-dir))
+           :package-dir
+           :+qi-directory+
+           :+qi-dep-dir+
+           :+global-package-dir+))
 (in-package :qi.paths)
 
 ;; Code:
 
-(defvar +project-name+ nil)
+;; Global paths
+
+(defvar +qi-directory+ (merge-pathnames ".qi/" (user-homedir-pathname))
+  "Pathname for the global ~/.qi directory.")
+
+(defvar +qi-dep-dir+ (merge-pathnames "dependencies/" +qi-directory+)
+  "Pathname for the global ~/.qi/dependencies directory.")
+
+(defvar +global-package-dir+
+  (merge-pathnames "packages/" +qi-directory+)
+  "Where globally installed user-packages live.")
+
+;; Project local paths
+
+(defvar +project-name+ nil
+  "Name of the current, local project (from qi.yaml).  Returns NIL if
+Qi is not running in the context of a project.")
 
 (defun project-dir (proj)
+  "Pathname/directory for <proj>."
   (asdf:system-relative-pathname proj (qi.util:sym->str proj)))
 
 (defun qi-dir ()

--- a/src/qi.lisp
+++ b/src/qi.lisp
@@ -130,14 +130,3 @@
                 (format t "~%  ~A (required by ~S)"
                         (transitive-dependency-name d)
                         (transitive-dependency-caller d)))))))
-
-(defun is-tar-url? (str)
-  (or (ppcre:scan "^https?.*.tgz" str)
-      (ppcre:scan "^https?.*tar.gz" str)))
-
-(defun is-git-url? (str)
-  (or (ppcre:scan "^git://.*" str)
-      (ppcre:scan ".*.git" str)))
-
-(defun is-gh-url? (str)
-  (ppcre:scan "^https?//github.*" str))

--- a/src/qi.lisp
+++ b/src/qi.lisp
@@ -2,6 +2,7 @@
 (defpackage qi
   (:use :cl)
   (:import-from :qi.util
+                :asdf-system-path
                 :is-tar-url?
                 :is-git-url?
                 :is-gh-url?)
@@ -29,7 +30,9 @@
                 :make-git-dependency
                 :http
                 :location)
-  (:export :install :hello))
+  (:export :install
+           :hello
+           :qiload))
 (in-package :qi)
 
 ;; code:
@@ -44,7 +47,9 @@
   (installed-dependency-report)
   (broken-dependency-report))
 
+
 (defun hello ()
+  "Qi status message."
   (format t "~%Qi - A Common Lisp Package Manager")
   (format t "~%Version 0.1")
   (format t "~%Source: https://github.com/CodyReichert/qi")

--- a/src/qi.lisp
+++ b/src/qi.lisp
@@ -32,7 +32,8 @@
                 :location)
   (:export :hello
            :install
-           :install-global))
+           :install-global
+           :up))
 (in-package :qi)
 
 ;; code:
@@ -60,6 +61,10 @@ another lisp session, use (qi:up <system>)."
   (asdf:oos 'asdf:load-op system :verbose nil)
   (installed-dependency-report)
   (broken-dependency-report))
+
+(defun up (system)
+  "Load <system> with system to it's available in the current lisp session."
+  (asdf:load-system system))
 
 
 (defun install (project)

--- a/src/qi.lisp
+++ b/src/qi.lisp
@@ -58,7 +58,7 @@ another lisp session, use (qi:up <system>)."
    (make-manifest-dependency
     :name (qi.util:sym->str system)
     :version version))
-  (asdf:oos 'asdf:load-op system :verbose nil)
+  (asdf:load-system system)
   (installed-dependency-report)
   (broken-dependency-report))
 

--- a/src/qi.lisp
+++ b/src/qi.lisp
@@ -65,29 +65,36 @@
          (cond ((eql nil (gethash "url" p))
                 (dispatch-dependency
                  (make-manifest-dependency :name (gethash "name" p)
-                                           :version (or (gethash "version" p) "latest")
-                                           :location (or (gethash "url" p) nil))))
+                                           :version (or (gethash "version" p)
+                                                        "latest")
+                                           :location (or (gethash "url" p)
+                                                         nil))))
                ;; Dependency is a tarball url
                ((is-tar-url? (gethash "url" p))
                 (dispatch-dependency
                  (make-http-dependency :name (gethash "name" p)
                                        :download-strategy "tarball"
-                                       :version (or (gethash "version" p) "latest")
-                                       :location (or (http (gethash "url" p)) nil))))
+                                       :version (or (gethash "version" p)
+                                                    "latest")
+                                       :location (or (http (gethash "url" p))
+                                                     nil))))
                ;; Dependency is git url
                ((or (is-git-url? (gethash "url" p))
                     (is-gh-url? (gethash "url" p)))
                 (dispatch-dependency
                  (make-git-dependency :name (gethash "name" p)
                                       :download-strategy "git"
-                                      :version (or (gethash "version" p) "latest")
-                                      :location (or (gethash "url" p) nil))))
+                                      :version (or (gethash "version" p)
+                                                   "latest")
+                                      :location (or (gethash "url" p)
+                                                    nil))))
                ;; Dependency is local path
                ((not (null (gethash "path" p)))
                 (dispatch-dependency
                  (make-local-dependency :name (gethash "name" p)
                                         :download-strategy "local"
-                                        :version (or (gethash "version" p) "latest")
+                                        :version (or (gethash "version" p)
+                                                     "latest")
                                         :location (or (gethash "url" p) nil))))
 
                (t (format t "~%---X Cannot resolve dependency type"))))
@@ -100,12 +107,15 @@
   (cond ((= 0 (length *qi-dependencies*))
          (format t "~%~%No dependencies installed!"))
         (t
-         (let ((installed (remove-if-not #'(lambda (x) (dependency-sys-path x)) *qi-dependencies*)))
+         (let ((installed (remove-if-not #'(lambda (x)
+                                             (dependency-sys-path x))
+                                         *qi-dependencies*)))
            (format t "~%~%~S dependencies installed:" (length installed))
            (loop for d in *qi-dependencies*
               when (qi.packages::dependency-sys-path d) do
                 (format t "~%   * ~A" (dependency-name d))))
-         (format t "~%~A transitive dependencies installed" (length *qi-trans-dependencies*)))))
+         (format t "~%~A transitive dependencies installed"
+                 (length *qi-trans-dependencies*)))))
 
 (defun broken-dependency-report ()
   (cond ((not (= 0 (length *qi-broken-dependencies*)))

--- a/src/util.lisp
+++ b/src/util.lisp
@@ -1,10 +1,27 @@
 (in-package :cl-user)
 (defpackage qi.util
   (:use :cl)
-  (:export :sym->str))
+  (:export :sym->str
+           :is-tar-url?
+           :is-git-url?
+           :is-gh-url?))
 (in-package :qi.util)
 
 ;; Code:
 
 (defun sym->str (sym)
   (string-downcase (symbol-name sym)))
+
+(defun is-tar-url? (str)
+  "Does <str> have a tarball extension."
+  (or (ppcre:scan "^https?.*.tgz" str)
+      (ppcre:scan "^https?.*tar.gz" str)))
+
+(defun is-git-url? (str)
+  "Is <str> a git:// or .git url."
+  (or (ppcre:scan "^git://.*" str)
+      (ppcre:scan ".*.git" str)))
+
+(defun is-gh-url? (str)
+  "Is <str> a github url."
+  (ppcre:scan "^https?//github.*" str))

--- a/src/util.lisp
+++ b/src/util.lisp
@@ -1,15 +1,17 @@
 (in-package :cl-user)
 (defpackage qi.util
   (:use :cl)
-  (:export :sym->str
+  (:export :asdf-system
            :is-tar-url?
            :is-git-url?
-           :is-gh-url?))
+           :is-gh-url?
+           :sym->str))
 (in-package :qi.util)
 
 ;; Code:
 
 (defun sym->str (sym)
+  ":<sym> -> \"sym\"."
   (string-downcase (symbol-name sym)))
 
 (defun is-tar-url? (str)
@@ -25,3 +27,10 @@
 (defun is-gh-url? (str)
   "Is <str> a github url."
   (ppcre:scan "^https?//github.*" str))
+
+
+(defun asdf-system-path (sys)
+  "Find the pathname for a system, return NIL if it's not available."
+  (handler-case
+      (asdf:component-pathname (asdf:find-system sys))
+    (error () () nil)))


### PR DESCRIPTION
New commands for installing libraries globally: `install-global` and `up`.

Minor fixes like whitespace cleanup, and line breaks
