### PR TITLE
Add a new type of packages: mercurial

### DIFF
--- a/src/util.lisp
+++ b/src/util.lisp
@@ -6,6 +6,7 @@
            :is-tar-url?
            :is-git-url?
            :is-gh-url?
+           :is-hg-url?
            :sym->str))
 (in-package :qi.util)
 
@@ -25,9 +26,14 @@
   (or (ppcre:scan "^git://.*" str)
       (ppcre:scan ".*.git" str)))
 
+(defun is-hg-url? (str)
+  "Is <str> a hg:// or .hg url."
+  (or (ppcre:scan "^hg://.*" str)
+      (ppcre:scan ".*.hg" str)))
+
 (defun is-gh-url? (str)
   "Is <str> a github url."
-  (ppcre:scan "^https?//github.*" str))
+  (ppcre:scan "^https://github.*" str))
 
 
 (defun asdf-system-path (sys)

--- a/t/qi.lisp
+++ b/t/qi.lisp
@@ -7,8 +7,43 @@
 
 ;; NOTE: To run this test file, execute `(asdf:test-system :qi)' in your Lisp.
 
-(plan nil)
+(plan 11)
 
-;; blah blah blah.
+
+;; -------------------
+;; Utils tests
+
+(ok (qi.util::is-tar-url? "https://github.com/CodyReichert/qi/master/master.tar.gz"))
+
+(ok (qi.util::is-git-url? "https://github.com/CodyReichert/qi"))
+(ok (qi.util::is-git-url? "https://github.com/CodyReichert/qi.git"))
+
+(ok (qi.util::is-gh-url? "https://github.com/CodyReichert/qi"))
+
+(ok (qi.util::is-hg-url? "https://bitbucket.org/tarballs_are_good/map-set.hg"))
+
+;; -------------------
+;; Dependencies tests
+
+(let ((config
+        (yaml:parse
+         (merge-pathnames #p"qi.yaml" "t/resources/git/"))))
+  (ok "qi-git-test" (gethash "name" config))
+  (let* ((p (car (gethash "packages" config)))
+         (dep (qi::extract-dependency p)))
+    (is (qi.packages::dependency-download-strategy dep) "git")
+    (is (qi.packages::dependency-location dep)
+        "https://github.com/sharplispers/split-sequence.git")))
+
+(let ((config
+        (yaml:parse
+         (merge-pathnames #p"qi.yaml" "t/resources/hg/"))))
+  (ok "qi-hg-test" (gethash "name" config))
+  (let* ((p (car (gethash "packages" config)))
+         (dep (qi::extract-dependency p)))
+    (is (qi.packages::dependency-download-strategy dep) "hg")
+    (is (qi.packages::dependency-location dep)
+        "https://bitbucket.org/tarballs_are_good/map-set")))
+
 
 (finalize)

--- a/t/resources/git/qi.yaml
+++ b/t/resources/git/qi.yaml
@@ -1,0 +1,4 @@
+name: qi-git-test
+packages:
+    - name: split-sequence
+      url: https://github.com/sharplispers/split-sequence.git

--- a/t/resources/hg/qi.yaml
+++ b/t/resources/hg/qi.yaml
@@ -1,0 +1,4 @@
+name: qi-hg-test
+packages:
+    - name: map-set
+      url: https://bitbucket.org/tarballs_are_good/map-set.hg


### PR DESCRIPTION
Add Mercurial (hg) to the list of availables types of packages
(manifest, tarball and git)

Some unit tests are provided : 

``` lisp
CL-USER> (asdf:test-system :qi)
Running a test file '/home/nicolas/qi/t/qi.lisp'
1..11

  ✓ 0 is expected to be T 
  ✓ 0 is expected to be T 
  ✓ 0 is expected to be T 
  ✓ 0 is expected to be T 
  ✓ 0 is expected to be T 
  ✓ qi-git-test 
  ✓ "git" is expected to be "git" 
  ✓ "https://github.com/sharplispers/split-sequence.git" is expected to be "https://github.com/sharplispers/split-sequence.git" 
  ✓ qi-hg-test 
  ✓ "hg" is expected to be "hg" 
  ✓ "https://bitbucket.org/tarballs_are_good/map-set" is expected to be "https://bitbucket.org/tarballs_are_good/map-set" 

✓ 11 tests completed (0ms)
T
```
