### PR TITLE
bin/qi: load init.lisp

### DIFF
--- a/bin/qi
+++ b/bin/qi
@@ -1,3 +1,10 @@
-#!/usr/bin/env sh
+#!/bin/bash
 
-sbcl --noinform --non-interactive --load $HOME/.qi/src/cli.lisp --end-toplevel-options "$@"
+set -e
+
+cd "$(dirname ${BASH_SOURCE[0]})/../"
+
+sbcl --noinform --non-interactive \
+     --load init.lisp \
+     --load src/cli.lisp \
+     --end-toplevel-options "$@"


### PR DESCRIPTION
Without this I see the following error:

```
$ bin/qi --install alexandria
While evaluating the form starting at line 2, column 0
  of #P"/Users/cat/Documents/clones/qi/src/cli.lisp":
Unhandled SB-KERNEL:SIMPLE-PACKAGE-ERROR in thread #<SB-THREAD:THREAD "main thread" RUNNING
                                                      {10028F6FD3}>:
  The name "QI" does not designate any package.
```
