### PR TITLE
fix broken manifests

### DIFF
--- a/manifest/manifest.lisp
+++ b/manifest/manifest.lisp
@@ -990,10 +990,6 @@
     :LOCATIONS (("latest" . "https://github.com/AeroNotix/ryeboy.git")))
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "rutils"
-    :VC "tagged-git"
-    :LOCATIONS (("latest" . "https://github.com/vseloved/rutils.git 1.0.0")))
- #S(QI.MANIFEST::MANIFEST-PACKAGE
-    :NAME "rutils"
     :VC "git"
     :LOCATIONS (("latest" . "https://github.com/vseloved/rutils.git")))
  #S(QI.MANIFEST::MANIFEST-PACKAGE

--- a/manifest/manifest.lisp
+++ b/manifest/manifest.lisp
@@ -40,8 +40,8 @@
     :LOCATIONS (("latest" . "https://github.com/xach/zaws.git")))
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "yason"
-    :VC "http"
-    :LOCATIONS (("latest" . "http://netzhansa.com/yason.tar.gz")))
+    :VC "git"
+    :LOCATIONS (("latest" . "https://github.com/hanshuebner/yason.git")))
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "yaclml"
     :VC "git"


### PR DESCRIPTION
The yason tarball is corrupted, and the second rutils entry causes Qi to make a list of the manifests, leading to this error:

```
$ bin/qi -i rutils
---> Installing "rutils"
-> Preparing to install manifest dependency: "rutils"
---> Found package in manifest!
   × An error occured: The value
                         (#S(QI.MANIFEST:MANIFEST-PACKAGE
                             :NAME "rutils"
                             :VC "tagged-git"
                             :LOCATIONS (("latest"
                                          . "https://github.com/vseloved/rutils.git 1.0.0")))
                          #S(QI.MANIFEST:MANIFEST-PACKAGE
                             :NAME "rutils"
                             :VC "git"
                             :LOCATIONS (("latest"
                                          . "https://github.com/vseloved/rutils.git"))))
                       is not of type
                         QI.MANIFEST:MANIFEST-PACKAGE
```
