### PR TITLE
cli: add --install-deps command

### DIFF
--- a/README.org
+++ b/README.org
@@ -81,6 +81,12 @@ View the HTML version of this documentation [[http://codyreichert.github.io/qi/]
      * (qi:install :myproject)
    #+END_SRC
 
+   You can also install project dependencies from the command-line:
+
+   #+BEGIN_SRC sh
+     qi --install-deps path/to/myproject.asd
+   #+END_SRC
+
    Qi take's care of any transitive dependencies and will let you know
    of any that it could /not/ install. In a case where Qi can not
    install some dependencies, add direct links to those packages in
@@ -206,12 +212,13 @@ View the HTML version of this documentation [[http://codyreichert.github.io/qi/]
    λ qi -h
    Qi - A simple, open, free package manager for Common Lisp.
 
-   Usage: qi [-h|--help] [-u|--upgrade] [-i|--install PACKAGE] [Free-Args]
+   Usage: qi [-h|--help] [-u|--upgrade] [-i|--install PACKAGE] [-d|--install-deps ASD-FILE] [Free-Args]
 
    Available options:
-     -h, --help               Print this help menu.
-     -u, --upgrade            Upgrade Qi (pull the latest from git)
-     -i, --install PACKAGE    Install a package from Qi (global by default)
+     -h, --help                   Print this help menu.
+     -u, --upgrade                Upgrade Qi (pull the latest from git)
+     -i, --install PACKAGE        Install a package from Qi (global by default)
+     -d, --install-deps ASD-FILE  Install dependencies locally for the specified system
 
    Issues https://github.com/CodyReichert/qi
    #+END_SRC

--- a/bin/qi
+++ b/bin/qi
@@ -1,10 +1,8 @@
 #!/bin/bash
 
-set -e
-
-cd "$(dirname ${BASH_SOURCE[0]})/../"
+QI_PREFIX=${QI_PREFIX:-"$(dirname ${BASH_SOURCE[0]})/.."}
 
 sbcl --noinform --non-interactive \
-     --load init.lisp \
-     --load src/cli.lisp \
+     --load "$QI_PREFIX"/init.lisp \
+     --load "$QI_PREFIX"/src/cli.lisp \
      --end-toplevel-options "$@"

--- a/docs/qi.html
+++ b/docs/qi.html
@@ -4,7 +4,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
 <head>
 <title>README</title>
-<!-- 2016-10-22 Sat 20:30 -->
+<!-- 2016-10-24 Mon 17:59 -->
 <meta  http-equiv="Content-Type" content="text/html;charset=utf-8" />
 <meta  name="viewport" content="width=device-width, initial-scale=1" />
 <meta  name="generator" content="Org-mode" />
@@ -315,6 +315,16 @@ to install and load the systems:
 </div>
 
 <p>
+You can also install project dependencies from the command-line:
+</p>
+
+<div class="org-src-container">
+
+<pre class="src src-sh">qi --install-deps path/to/myproject.asd
+</pre>
+</div>
+
+<p>
 Qi take's care of any transitive dependencies and will let you know
 of any that it could <i>not</i> install. In a case where Qi can not
 install some dependencies, add direct links to those packages in
@@ -548,12 +558,13 @@ Run <code>$ qi --help</code> For info on the available commands:
 <pre class="src src-sh">&#955; qi -h
 Qi - A simple, open, free package manager for Common Lisp.
 
-Usage: qi [-h|--help] [-u|--upgrade] [-i|--install PACKAGE] [Free-Args]
+Usage: qi [-h|--help] [-u|--upgrade] [-i|--install PACKAGE] [-d|--install-deps ASD-FILE] [Free-Args]
 
 Available options:
-  -h, --help               Print this help menu.
-  -u, --upgrade            Upgrade Qi (pull the latest from git)
-  -i, --install PACKAGE    Install a package from Qi (global by default)
+  -h, --help                   Print this help menu.
+  -u, --upgrade                Upgrade Qi (pull the latest from git)
+  -i, --install PACKAGE        Install a package from Qi (global by default)
+  -d, --install-deps ASD-FILE  Install dependencies locally for the specified system
 
 Issues https://github.com/CodyReichert/qi
 </pre>
@@ -630,7 +641,7 @@ BSD
 </div>
 </div>
 <div id="postamble" class="status">
-<p class="date">Created: 2016-10-22 Sat 20:30</p>
+<p class="date">Created: 2016-10-24 Mon 17:59</p>
 <p class="validation"><a href="http://validator.w3.org/check?uri=referer">Validate</a></p>
 </div>
 </body>

--- a/src/cli.lisp
+++ b/src/cli.lisp
@@ -29,8 +29,13 @@
      :short #\i
      :long "install"
      :arg-parser #'identity
-     :command "install"
-     :meta-var "PACKAGE"))
+     :meta-var "PACKAGE")
+    (:name :install-deps
+     :description "Install local dependencies for the specified system"
+     :short #\d
+     :long "install-deps"
+     :arg-parser #'identity
+     :meta-var "ASD-FILE"))
 
 
 (defun unknown-option (cond)
@@ -44,8 +49,13 @@
        ,@body)))
 
 
-;;; Qi Install ($ qi --install [package] / $ qi -i [package]) internals
+;;; Qi install-deps ($ qi --install-deps project.asd)
+(defun opt-install-deps (input)
+  "Install the dependencies locally for the system definition file provided as INPUT."
+  (load input)
+  (qi:install (pathname-name input)))
 
+;;; Qi Install ($ qi --install [package] / $ qi -i [package]) internals
 (defun opt-install (opt)
   "Install a package to Qi global package directory. The package will be available
 in all future lisp sessions."
@@ -106,6 +116,8 @@ in all future lisp sessions."
      :usage-of "qi"
      :args "[Free-Args]"))
   (when-option (options :upgrade)
-    (run-qi-upgrade))
+               (run-qi-upgrade))
   (when-option (options :install)
-    (opt-install (getf options :install))))
+               (opt-install (getf options :install)))
+  (when-option (options :install-deps)
+               (opt-install-deps (getf options :install-deps))))


### PR DESCRIPTION
Installs a system's dependencies into the local .dependency directory

Usage:

```
qi --install-deps path/to/system.asd
```
