### PR TITLE
manifest: update usocket source

### DIFF
--- a/manifest/manifest.lisp
+++ b/manifest/manifest.lisp
@@ -256,9 +256,9 @@
                  . "https://github.com/scymtym/utilities.binary-dump.git")))
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "usocket"
-    :VC "http"
+    :VC "git"
     :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/usocket/releases/usocket-latest.tar.gz")))
+                 . "https://github.com/usocket/usocket.git")))
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "usocket-udp"
     :VC "http"


### PR DESCRIPTION
The release tarball from common-lisp.net is missing the vendored
split-sequence from the components list, which causes compilation to
fail.

Fixes #18.
