### PR TITLE
init.lisp: prefer vendored deps over global .deps

### DIFF
--- a/init.lisp
+++ b/init.lisp
@@ -73,11 +73,11 @@ available like qi, but can be make so by (qi:qiload :<system>)."
 ;; globally-installed packages.
 (let ((qi-deps-to-load (directory (concatenate 'string (namestring +qi-dependencies+) "**"))))
   (setf asdf:*central-registry* nil)
+  (load-user-packages)
   (push-new-to-registry +qi-directory+)
   (loop for d in qi-deps-to-load
      do
-       (push-new-to-registry d))
-  (load-user-packages))
+       (push-new-to-registry d)))
 
 
 ;; Load Qi


### PR DESCRIPTION
Currently, the global packages installed in qi/.dependencies are placed
before the vendored qi/dependencies in the _central-registry_.  As a
result, if the user tries to globally install a broken version of a Qi
dependency (see #21), it can break Qi:

```
$ qi -i usocket

---> Installing "usocket"
-> Preparing to install manifest dependency: "usocket"
---> Found package in manifest!
---> Resolved version "latest" for "usocket"
WARNING: redefining PERFORM (#<STANDARD-CLASS ASDF/LISP-ACTION:TEST-OP> #<SB-MOP:EQL-SPECIALIZER #<SYSTEM "usocket">>) in DEFMETHOD
---> Downloading tarball from "http://common-lisp.net/project/usocket/releases/usocket-latest.tar.gz"
   × An error occured: Component :SPLIT-SEQUENCE not found, required by
                       #<SYSTEM "usocket">

$ qi -i usocket
While evaluating the form starting at line 2, column 0
  of #P"/Users/cat/Documents/clones/qi/src/cli.lisp":
Unhandled SB-KERNEL:SIMPLE-PACKAGE-ERROR in thread #<SB-THREAD:THREAD "main thread" RUNNING
                                                      {10028F7183}>:
  The name "QI" does not designate any package.

Backtrace for: #<SB-THREAD:THREAD "main thread" RUNNING {10028F7183}>
0: (SB-DEBUG::DEBUGGER-DISABLED-HOOK #<SB-KERNEL:SIMPLE-PACKAGE-ERROR "The name ~S does not designate any package." {1004705383}> #<unavailable argument>)
1: (SB-DEBUG::RUN-HOOK *INVOKE-DEBUGGER-HOOK* #<SB-KERNEL:SIMPLE-PACKAGE-ERROR "The name ~S does not designate anypackage." {1004705383}>)
2: (INVOKE-DEBUGGER #<SB-KERNEL:SIMPLE-PACKAGE-ERROR "The name ~S does not designate any package." {1004705383}>)
3: (ERROR SB-KERNEL:SIMPLE-PACKAGE-ERROR :PACKAGE "QI" :FORMAT-CONTROL "The name ~S does not designate any package." :FORMAT-ARGUMENTS ("QI"))
4: (SB-INT:FIND-UNDELETED-PACKAGE-OR-LOSE "QI")
5: (SB-IMPL::USE-LIST-PACKAGES NIL ("CL" "QI"))
6: ((FLET SB-IMPL::THUNK :IN SB-IMPL::%DEFPACKAGE))
7: ((FLET #:WITHOUT-INTERRUPTS-BODY-387 :IN SB-THREAD::CALL-WITH-RECURSIVE-LOCK))
8: (SB-THREAD::CALL-WITH-RECURSIVE-LOCK #<CLOSURE (FLET SB-THREAD::WITH-RECURSIVE-LOCK-THUNK :IN SB-IMPL::CALL-WITH-PACKAGE-GRAPH) {19FF01B}> #<SB-THREAD:MUTEX "Package Graph Lock" owner: #<SB-THREAD:THREAD "main thread" RUNNING {10028F7183}>> T NIL)
9: (SB-IMPL::CALL-WITH-PACKAGE-GRAPH #<CLOSURE (FLET SB-IMPL::THUNK :IN SB-IMPL::%DEFPACKAGE) {19FF06B}>)
10: (SB-IMPL::%DEFPACKAGE "QI.CLI" NIL NIL NIL NIL ("CL" "QI") (("QI.UTIL" "SYM->STR") ("QI.PATHS" "+QI-DIRECTORY+") ("QI.PACKAGES" "MAKE-DEPENDENCY") ("TRIVIAL-SHELL" "SHELL-COMMAND")) NIL NIL ("QI.CLI") NIL NIL #S(SB-C:DEFINITION-SOURCE-LOCATION :NAMESTRING "/Users/cat/Documents/clones/qi/src/cli.lisp" :TOPLEVEL-FORM-NUMBER 1 :FORM-NUMBER NIL :PLIST NIL) NIL)
11: (SB-INT:SIMPLE-EVAL-IN-LEXENV (SB-IMPL::%DEFPACKAGE #1="QI.CLI" (QUOTE NIL) (QUOTE NIL) (QUOTE NIL) (QUOTE NIL) (QUOTE ("CL" "QI")) (QUOTE (("QI.UTIL" "SYM->STR") ("QI.PATHS" "+QI-DIRECTORY+") ("QI.PACKAGES" "MAKE-DEPENDENCY") ("TRIVIAL-SHELL" "SHELL-COMMAND"))) (QUOTE NIL) (QUOTE NIL) (QUOTE (#1#)) (QUOTE NIL) ...) #<NULL-LEXENV>)
12: (SB-INT:SIMPLE-EVAL-IN-LEXENV (DEFPACKAGE QI.CLI (:USE :CL :QI) (:IMPORT-FROM :TRIVIAL-SHELL :SHELL-COMMAND) (:IMPORT-FROM :QI.PACKAGES :MAKE-DEPENDENCY) (:IMPORT-FROM :QI.PATHS :+QI-DIRECTORY+) (:IMPORT-FROM :QI.UTIL :SYM->STR)) #<NULL-LEXENV>)
13: (EVAL-TLF (DEFPACKAGE QI.CLI (:USE :CL :QI) (:IMPORT-FROM :TRIVIAL-SHELL :SHELL-COMMAND) (:IMPORT-FROM :QI.PACKAGES :MAKE-DEPENDENCY) (:IMPORT-FROM :QI.PATHS :+QI-DIRECTORY+) (:IMPORT-FROM :QI.UTIL :SYM->STR)) 1 NIL)
14: ((LABELS SB-FASL::EVAL-FORM :IN SB-INT:LOAD-AS-SOURCE) (DEFPACKAGE QI.CLI (:USE :CL :QI) (:IMPORT-FROM :TRIVIAL-SHELL :SHELL-COMMAND) (:IMPORT-FROM :QI.PACKAGES :MAKE-DEPENDENCY) (:IMPORT-FROM :QI.PATHS :+QI-DIRECTORY+) (:IMPORT-FROM :QI.UTIL :SYM->STR)) 1)
15: ((LAMBDA (SB-KERNEL:FORM &KEY :CURRENT-INDEX &ALLOW-OTHER-KEYS) :IN SB-INT:LOAD-AS-SOURCE) (DEFPACKAGE QI.CLI (:USE :CL :QI) (:IMPORT-FROM :TRIVIAL-SHELL :SHELL-COMMAND) (:IMPORT-FROM :QI.PACKAGES :MAKE-DEPENDENCY) (:IMPORT-FROM :QI.PATHS :+QI-DIRECTORY+) (:IMPORT-FROM :QI.UTIL :SYM->STR)) :CURRENT-INDEX 1)
16: (SB-C::%DO-FORMS-FROM-INFO #<CLOSURE (LAMBDA (SB-KERNEL:FORM &KEY :CURRENT-INDEX &ALLOW-OTHER-KEYS) :IN SB-INT:LOAD-AS-SOURCE) {10046F0BBB}> #<SB-C::SOURCE-INFO {10046F0B73}> SB-C::INPUT-ERROR-IN-LOAD)
17: (SB-INT:LOAD-AS-SOURCE #<SB-INT:FORM-TRACKING-STREAM for "file /Users/cat/Documents/clones/qi/src/cli.lisp" {10046EE0E3}> :VERBOSE NIL :PRINT NIL :CONTEXT "loading")
18: ((FLET SB-FASL::LOAD-STREAM :IN LOAD) #<SB-INT:FORM-TRACKING-STREAM for "file /Users/cat/Documents/clones/qi/src/cli.lisp" {10046EE0E3}> NIL)
19: (LOAD #P"/Users/cat/Documents/clones/qi/src/cli.lisp" :VERBOSE NIL :PRINT NIL :IF-DOES-NOT-EXIST T :EXTERNAL-FORMAT :DEFAULT)
20: (SB-IMPL::PROCESS-EVAL/LOAD-OPTIONS ((:LOAD . "/Users/cat/Documents/clones/qi/init.lisp") (:LOAD . "/Users/cat/Documents/clones/qi/src/cli.lisp") (:QUIT)))
21: (SB-IMPL::TOPLEVEL-INIT)
22: ((FLET #:WITHOUT-INTERRUPTS-BODY-90 :IN SAVE-LISP-AND-DIE))
23: ((LABELS SB-IMPL::RESTART-LISP :IN SAVE-LISP-AND-DIE))

unhandled condition in --disable-debugger mode, quitting
```
