### PR TITLE
install all dependencies locally

### DIFF
--- a/src/qi.lisp
+++ b/src/qi.lisp
@@ -74,8 +74,9 @@ be in the CWD that specifies <project>'s dependencies."
   (let* ((base-dir (qi.paths:project-dir project))
          (qi-file (merge-pathnames #p"qi.yaml" base-dir)))
     (if (probe-file qi-file)
-        (install-from-qi-file qi-file)
-        (error "No qi.yaml!"))))
+        #+sbcl (sb-ext:without-package-locks (install-from-qi-file qi-file))
+        #-sbcl (install-from-qi-file qi-file)
+      (error "No qi.yaml!"))))
 
 
 (defun bootstrap (proj)


### PR DESCRIPTION
The effect of this change is for `qi:install` to attempt to install _all_ of a project's dependencies, even ones already loaded.

My use-case is to simplify projects by not requiring a runtime dependency on Qi.  I want to be able to have an `.asd` file that looks like this:
```lisp
(asdf:initialize-source-registry
 `(:source-registry
   :ignore-inherited-configuration
   (:tree (:here ".dependencies/packages/"))))

(asdf:defsystem #:my-project
   ...
```
Then I can just load it and go.

The second commit was required because SBCL would complain when recompiling Alexandria.  I don't understand why Alexandria is being locked in the first place since it's not a core part of SBCL, so maybe there's something here I'm missing.