### PR TITLE
manifests: replace location/vc with url

### DIFF
--- a/manifest/manifest.lisp
+++ b/manifest/manifest.lisp
@@ -1,5672 +1,3959 @@
 (#S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "zsort"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/jorgetavares/zsort.git")))
+    :URL "https://github.com/jorgetavares/zsort.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "zs3"
-    :VC "http"
-    :LOCATIONS (("latest" . "http://www.xach.com/lisp/zs3.tgz")))
+    :URL "http://www.xach.com/lisp/zs3.tgz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "zpng"
-    :VC "http"
-    :LOCATIONS (("latest" . "http://www.xach.com/lisp/zpng.tgz")))
+    :URL "http://www.xach.com/lisp/zpng.tgz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "zpb-ttf"
-    :VC "http"
-    :LOCATIONS (("latest" . "http://www.xach.com/lisp/zpb-ttf.tgz")))
+    :URL "http://www.xach.com/lisp/zpb-ttf.tgz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "zpb-exif"
-    :VC "http"
-    :LOCATIONS (("latest" . "http://www.xach.com/lisp/zpb-exif.tgz")))
+    :URL "http://www.xach.com/lisp/zpb-exif.tgz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "zlib"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://gitlab.common-lisp.net/zlib/zlib.git")))
+    :URL "https://gitlab.common-lisp.net/zlib/zlib.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "zip"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/bluelisp/zip.git")))
+    :URL "https://github.com/bluelisp/zip.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "zenekindarl"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/KeenS/zenekindarl.git")))
+    :URL "https://github.com/KeenS/zenekindarl.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "zcdb"
-    :VC "http"
-    :LOCATIONS (("latest" . "http://www.xach.com/lisp/zcdb.tgz")))
+    :URL "http://www.xach.com/lisp/zcdb.tgz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "zaws"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/xach/zaws.git")))
+    :URL "https://github.com/xach/zaws.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "yason"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/hanshuebner/yason.git")))
+    :URL "https://github.com/hanshuebner/yason.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "yaclml"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/sharplispers/yaclml.git")))
+    :URL "https://github.com/sharplispers/yaclml.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "yaclanapht"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/mabragor/anaphora.git")))
+    :URL "https://github.com/mabragor/anaphora.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "xuriella"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://repo.or.cz/xuriella.git")))
+    :URL "https://repo.or.cz/xuriella.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "xsubseq"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/fukamachi/xsubseq.git")))
+    :URL "https://github.com/fukamachi/xsubseq.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "xptest"
-    :VC "kmr-git"
-    :LOCATIONS (("latest" . "xptest")))
+    :URL "xptest")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "xmlutils"
-    :VC "kmr-git"
-    :LOCATIONS (("latest" . "xmlutils")))
+    :URL "xmlutils")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "xmls"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/xmls/xmls-1.7.tgz")))
+    :URL "http://common-lisp.net/project/xmls/xmls-1.7.tgz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "xmls-tools"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://www.bobturf.org/software/xmls-tools/xmls-tools-0.2.0.tar.gz")))
+    :URL "http://www.bobturf.org/software/xmls-tools/xmls-tools-0.2.0.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "xml.location"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/scymtym/xml.location.git")))
+    :URL "https://github.com/scymtym/xml.location.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "xml-mop"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/gonzojive/xml-mop.git")))
+    :URL "https://github.com/gonzojive/xml-mop.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "xml-emitter"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/asdf-packaging/xml-emitter-latest.tar.gz")))
+    :URL "http://common-lisp.net/project/asdf-packaging/xml-emitter-latest.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "xlunit"
-    :VC "kmr-git"
-    :LOCATIONS (("latest" . "xlunit")))
+    :URL "xlunit")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "xhtmlgen"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/hanshuebner/xhtmlgen.git")))
+    :URL "https://github.com/hanshuebner/xhtmlgen.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "xhtmlambda"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://gitlab.common-lisp.net/xhtmlambda/XHTMLambda.git")))
+    :URL "https://gitlab.common-lisp.net/xhtmlambda/XHTMLambda.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "xecto"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/pkhuong/Xecto.git")))
+    :URL "https://github.com/pkhuong/Xecto.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "xarray"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/blindglobe/xarray.git")))
+    :URL "https://github.com/blindglobe/xarray.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "x.let-star"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/ks/X.LET-STAR.git")))
+    :URL "https://github.com/ks/X.LET-STAR.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "x.fdatatypes"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/ks/X.FDATATYPES.git")))
+    :URL "https://github.com/ks/X.FDATATYPES.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "wuwei"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/mtravers/wuwei.git")))
+    :URL "https://github.com/mtravers/wuwei.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "wu-sugar"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Wukix/wu-sugar.git")))
+    :URL "https://github.com/Wukix/wu-sugar.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "wu-decimal"
-    :VC "git"
-    :LOCATIONS (("latest" . "http://wukix.com/dist/wu-decimal.git")))
+    :URL "http://wukix.com/dist/wu-decimal.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "workout-timer"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://gitlab.common-lisp.net/frideau/workout-timer.git")))
+    :URL "https://gitlab.common-lisp.net/frideau/workout-timer.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "wookie"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/orthecreedence/wookie.git")))
+    :URL "https://github.com/orthecreedence/wookie.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "woo"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/fukamachi/woo.git")))
+    :URL "https://github.com/fukamachi/woo.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "with-c-syntax"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/y2q-actionman/with-c-syntax.git")))
+    :URL "https://github.com/y2q-actionman/with-c-syntax.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "whistle"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/gigamonkey/whistle.git")))
+    :URL "https://github.com/gigamonkey/whistle.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "weft"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/mtstickney/weft.git")))
+    :URL "https://github.com/mtstickney/weft.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "websocket-driver"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/fukamachi/websocket-driver.git")))
+    :URL "https://github.com/fukamachi/websocket-driver.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "weblocks"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/skypher/weblocks.git")))
+    :URL "https://github.com/skypher/weblocks.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "weblocks"
-    :VC "mercurial"
-    :LOCATIONS (("latest" . "https://bitbucket.org/S11001001/weblocks-dev")))
+    :URL "https://bitbucket.org/S11001001/weblocks-dev")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "weblocks-utils"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/html/weblocks-utils.git")))
+    :URL "https://github.com/html/weblocks-utils.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "weblocks-tree-widget"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/html/weblocks-tree-widget.git")))
+    :URL "https://github.com/html/weblocks-tree-widget.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "weblocks-stores"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/html/weblocks-stores.git")))
+    :URL "https://github.com/html/weblocks-stores.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "weblocks-examples"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/html/weblocks-examples.git")))
+    :URL "https://github.com/html/weblocks-examples.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "vom"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/orthecreedence/vom.git")))
+    :URL "https://github.com/orthecreedence/vom.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "vivace-graph"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/kraison/vivace-graph.git")))
+    :URL "https://github.com/kraison/vivace-graph.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "vgplot"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/volkers/vgplot.git")))
+    :URL "https://github.com/volkers/vgplot.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "vertex"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/CommonDoc/vertex.git")))
+    :URL "https://github.com/CommonDoc/vertex.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "verrazano"
-    :VC "darcs"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/fetter/darcs/verrazano/")))
+    :URL "http://common-lisp.net/project/fetter/darcs/verrazano/")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "verbose"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Shinmera/verbose.git")))
+    :URL "https://github.com/Shinmera/verbose.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "vector"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/elbeno/vector.git")))
+    :URL "https://github.com/elbeno/vector.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "vecto"
-    :VC "http"
-    :LOCATIONS (("latest" . "http://www.xach.com/lisp/vecto.tgz")))
+    :URL "http://www.xach.com/lisp/vecto.tgz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "vas-string-metrics"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/vsedach/vas-string-metrics.git")))
+    :URL "https://github.com/vsedach/vas-string-metrics.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "varjo"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/cbaggers/varjo.git")))
+    :URL "https://github.com/cbaggers/varjo.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "uuid"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/dardoria/uuid.git")))
+    :URL "https://github.com/dardoria/uuid.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "utm"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/jl2/utm.git")))
+    :URL "https://github.com/jl2/utm.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "utils-kt"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/kennytilton/utils-kt.git")))
+    :URL "https://github.com/kennytilton/utils-kt.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "utilities.print-tree"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/scymtym/utilities.print-tree.git")))
+    :URL "https://github.com/scymtym/utilities.print-tree.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "utilities.print-items"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/scymtym/utilities.print-items.git")))
+    :URL "https://github.com/scymtym/utilities.print-items.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "utilities.binary-dump"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/scymtym/utilities.binary-dump.git")))
+    :URL "https://github.com/scymtym/utilities.binary-dump.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "usocket"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/usocket/usocket.git")))
+    :URL "https://github.com/usocket/usocket.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "usocket-udp"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/cl-net-snmp/release/usocket-udp_latest.tar.gz")))
+    :URL "http://common-lisp.net/project/cl-net-snmp/release/usocket-udp_latest.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "userial"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://nklein.com/wp-content/uploads/2011/06/userial_0.8.2011.06.02.tar.gz")))
+    :URL "http://nklein.com/wp-content/uploads/2011/06/userial_0.8.2011.06.02.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "url-rewrite"
-    :VC "http"
-    :LOCATIONS (("latest" . "http://weitz.de/files/url-rewrite.tar.gz")))
+    :URL "http://weitz.de/files/url-rewrite.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "uri-template"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/uri-template/release/uri-template-latest.tgz")))
+    :URL "http://common-lisp.net/project/uri-template/release/uri-template-latest.tgz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "unix-opts"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/mrkkrp/unix-opts.git")))
+    :URL "https://github.com/mrkkrp/unix-opts.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "unix-options"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/astine/unix-options.git")))
+    :URL "https://github.com/astine/unix-options.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "universal-config"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/Shinmera/universal-config.git")))
+    :URL "https://github.com/Shinmera/universal-config.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "unit-test"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/hanshuebner/unit-test.git")))
+    :URL "https://github.com/hanshuebner/unit-test.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "unit-formula"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Ramarren/unit-formula.git")))
+    :URL "https://github.com/Ramarren/unit-formula.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "unicly"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/mon-key/unicly.git")))
+    :URL "https://github.com/mon-key/unicly.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "umlisp"
-    :VC "kmr-git"
-    :LOCATIONS (("latest" . "umlisp")))
+    :URL "umlisp")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "umlisp-orf"
-    :VC "kmr-git"
-    :LOCATIONS (("latest" . "umlisp-orf")))
+    :URL "umlisp-orf")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "uiop"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/asdf/archives/uiop.tar.gz")))
+    :URL "http://common-lisp.net/project/asdf/archives/uiop.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "ufo"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/ta2gch/UFO.git")))
+    :URL "https://github.com/ta2gch/UFO.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "uffi"
-    :VC "kmr-git"
-    :LOCATIONS (("latest" . "uffi")))
+    :URL "uffi")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "ucw"
-    :VC "darcs"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/ucw/repos/ucw-core/")))
+    :URL "http://common-lisp.net/project/ucw/repos/ucw-core/")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "ubiquitous"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Shinmera/ubiquitous.git")))
+    :URL "https://github.com/Shinmera/ubiquitous.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "type-r"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/guicho271828/type-r.git")))
+    :URL "https://github.com/guicho271828/type-r.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "type-i"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/guicho271828/type-i.git")))
+    :URL "https://github.com/guicho271828/type-i.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "twfy"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/jamtho/twfy.git")))
+    :URL "https://github.com/jamtho/twfy.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "trivialib.type-unify"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/guicho271828/trivialib.type-unify.git")))
+    :URL "https://github.com/guicho271828/trivialib.type-unify.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "trivial-utf-8"
-    :VC "http"
-    :LOCATIONS (("latest" . "http://common-lisp.net/project/trivial-utf-8/trivial-utf-8.tgz")))
+    :URL "http://common-lisp.net/project/trivial-utf-8/trivial-utf-8.tgz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "trivial-update"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/mrkkrp/trivial-update.git")))
+    :URL "https://github.com/mrkkrp/trivial-update.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "trivial-types"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/m2ym/trivial-types.git")))
+    :URL "https://github.com/m2ym/trivial-types.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "trivial-timers"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://releases.unknownlamer.org/trivial-timers/trivial-timers_latest.tar.gz")))
+    :URL "http://releases.unknownlamer.org/trivial-timers/trivial-timers_latest.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "trivial-timeout"
-    :VC "darcs"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/trivial-timeout/")))
+    :URL "http://common-lisp.net/project/trivial-timeout/")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "trivial-thumbnail"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/Shinmera/trivial-thumbnail.git")))
+    :URL "https://github.com/Shinmera/trivial-thumbnail.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "trivial-tco"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/rmoritz/trivial-tco.git")))
+    :URL "https://github.com/rmoritz/trivial-tco.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "trivial-signal"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/guicho271828/trivial-signal.git")))
+    :URL "https://github.com/guicho271828/trivial-signal.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "trivial-shell"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/gwkkwg/trivial-shell.git")))
+    :URL "https://github.com/gwkkwg/trivial-shell.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "trivial-raw-io"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/redline6561/trivial-raw-io.git")))
+    :URL "https://github.com/redline6561/trivial-raw-io.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "trivial-open-browser"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/eudoxia0/trivial-open-browser.git")))
+    :URL "https://github.com/eudoxia0/trivial-open-browser.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "trivial-octet-streams"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/froydnj/trivial-octet-streams.git")))
+    :URL "https://github.com/froydnj/trivial-octet-streams.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "trivial-mimes"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Shinmera/trivial-mimes.git")))
+    :URL "https://github.com/Shinmera/trivial-mimes.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "trivial-main-thread"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/Shinmera/trivial-main-thread.git")))
+    :URL "https://github.com/Shinmera/trivial-main-thread.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "trivial-ldap"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/rwiker/trivial-ldap.git")))
+    :URL "https://github.com/rwiker/trivial-ldap.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "trivial-lazy"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/dsorokin/trivial-lazy.git")))
+    :URL "https://github.com/dsorokin/trivial-lazy.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "trivial-irc"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/karvus/trivial-irc.git")))
+    :URL "https://github.com/karvus/trivial-irc.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "trivial-indent"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Shinmera/trivial-indent.git")))
+    :URL "https://github.com/Shinmera/trivial-indent.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "trivial-http"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/trivial-http/trivial-http.tar.gz")))
+    :URL "http://common-lisp.net/project/trivial-http/trivial-http.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "trivial-gray-streams"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/trivial-gray-streams/trivial-gray-streams.git")))
+    :URL "https://github.com/trivial-gray-streams/trivial-gray-streams.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "trivial-garbage"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/trivial-garbage/trivial-garbage.git")))
+    :URL "https://github.com/trivial-garbage/trivial-garbage.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "trivial-features"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/trivial-features/trivial-features.git")))
+    :URL "https://github.com/trivial-features/trivial-features.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "trivial-extract"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/eudoxia0/trivial-extract.git")))
+    :URL "https://github.com/eudoxia0/trivial-extract.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "trivial-dump-core"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/rolpereira/trivial-dump-core.git")))
+    :URL "https://github.com/rolpereira/trivial-dump-core.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "trivial-download"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/eudoxia0/trivial-download.git")))
+    :URL "https://github.com/eudoxia0/trivial-download.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "trivial-documentation"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/eugeneia/trivial-documentation.git")))
+    :URL "https://github.com/eugeneia/trivial-documentation.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "trivial-debug-console"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/mtstickney/trivial-debug-console.git")))
+    :URL "https://github.com/mtstickney/trivial-debug-console.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "trivial-channels"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/rpav/trivial-channels.git")))
+    :URL "https://github.com/rpav/trivial-channels.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "trivial-bit-streams"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/Lovesan/trivial-bit-streams.git")))
+    :URL "https://github.com/Lovesan/trivial-bit-streams.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "trivial-benchmark"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/Shinmera/trivial-benchmark.git")))
+    :URL "https://github.com/Shinmera/trivial-benchmark.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "trivial-backtrace"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://gitlab.common-lisp.net/trivial-backtrace/trivial-backtrace.git")))
+    :URL "https://gitlab.common-lisp.net/trivial-backtrace/trivial-backtrace.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "trivial-arguments"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/Shinmera/trivial-arguments.git")))
+    :URL "https://github.com/Shinmera/trivial-arguments.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "trivia"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/guicho271828/trivia.git")))
+    :URL "https://github.com/guicho271828/trivia.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "trivia.balland2006"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/guicho271828/trivia.balland2006.git")))
+    :URL "https://github.com/guicho271828/trivia.balland2006.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "trees"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/froydnj/trees")))
+    :URL "https://github.com/froydnj/trees")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "treedb"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/chfin/treedb.git")))
+    :URL "https://github.com/chfin/treedb.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "transparent-wrap"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/DalekBaldwin/transparent-wrap.git")))
+    :URL "https://github.com/DalekBaldwin/transparent-wrap.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "track-best"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "http://git.nklein.com/lisp/libs/track-best.git/")))
+    :URL "http://git.nklein.com/lisp/libs/track-best.git/")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "towers"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/death/towers.git")))
+    :URL "https://github.com/death/towers.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "torta"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/sgarciac/torta.git")))
+    :URL "https://github.com/sgarciac/torta.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "toot"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/gigamonkey/toot.git")))
+    :URL "https://github.com/gigamonkey/toot.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "toadstool"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/kisp/toadstool.git")))
+    :URL "https://github.com/kisp/toadstool.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "tinaa"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/gwkkwg/tinaa.git")))
+    :URL "https://github.com/gwkkwg/tinaa.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "time-interval"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/slyrus/time-interval.git")))
+    :URL "https://github.com/slyrus/time-interval.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "tiff4cl"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://wcp.sdf-eu.org/software/tiff4cl-latest.tbz")))
+    :URL "http://wcp.sdf-eu.org/software/tiff4cl-latest.tbz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "thread.comm.rendezvous"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/kkazuo/thread.comm.rendezvous.git")))
+    :URL "https://github.com/kkazuo/thread.comm.rendezvous.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "thread-pool"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/kiuma/thread-pool.git")))
+    :URL "https://github.com/kiuma/thread-pool.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "thorn"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/CommonDoc/thorn.git")))
+    :URL "https://github.com/CommonDoc/thorn.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "thnappy"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/flambard/thnappy.git")))
+    :URL "https://github.com/flambard/thnappy.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "text-query"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/asdf-packaging/text-query-latest.tar.gz")))
+    :URL "http://common-lisp.net/project/asdf-packaging/text-query-latest.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "texp"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/eugeneia/texp.git")))
+    :URL "https://github.com/eugeneia/texp.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "testbild"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/e-user/testbild.git")))
+    :URL "https://github.com/e-user/testbild.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "terminfo"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/npatrick04/terminfo.git")))
+    :URL "https://github.com/npatrick04/terminfo.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "temporary-file"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/hanshuebner/temporary-file.git")))
+    :URL "https://github.com/hanshuebner/temporary-file.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "temporal-functions"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/cbaggers/temporal-functions.git")))
+    :URL "https://github.com/cbaggers/temporal-functions.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "template"
-    :VC "mercurial"
-    :LOCATIONS (("latest"
-                 . "https://bitbucket.org/tarballs_are_good/template")))
+    :URL "https://bitbucket.org/tarballs_are_good/template")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "telnetlib"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/brianjcj/telnetlib-for-common-lisp.git")))
+    :URL "https://github.com/brianjcj/telnetlib-for-common-lisp.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "teepeedee2"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/vii/teepeedee2.git")))
+    :URL "https://github.com/vii/teepeedee2.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "tbnl"
-    :VC "http"
-    :LOCATIONS (("latest" . "http://weitz.de/files/tbnl.tar.gz")))
+    :URL "http://weitz.de/files/tbnl.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "tap-unit-test"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/jhanley634/tap-unit-test.git")))
+    :URL "https://github.com/jhanley634/tap-unit-test.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "talcl"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/AccelerationNet/talcl.git")))
+    :URL "https://github.com/AccelerationNet/talcl.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "tagger"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/g000001/tagger.git")))
+    :URL "https://github.com/g000001/tagger.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "synonyms"
-    :VC "mercurial"
-    :LOCATIONS (("latest"
-                 . "https://bitbucket.org/tarballs_are_good/synonyms")))
+    :URL "https://bitbucket.org/tarballs_are_good/synonyms")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "symbol-namespaces"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://tarballs.hexstreamsoft.com/libraries/latest/symbol-namespaces_latest.tar.gz")))
+    :URL "http://tarballs.hexstreamsoft.com/libraries/latest/symbol-namespaces_latest.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "symbol-munger"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/AccelerationNet/symbol-munger.git")))
+    :URL "https://github.com/AccelerationNet/symbol-munger.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "sxql"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/fukamachi/sxql.git")))
+    :URL "https://github.com/fukamachi/sxql.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "swap-bytes"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/sionescu/swap-bytes.git")))
+    :URL "https://github.com/sionescu/swap-bytes.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "swank-protocol"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/eudoxia0/swank-protocol.git")))
+    :URL "https://github.com/eudoxia0/swank-protocol.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "swank-crew"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/brown/swank-crew.git")))
+    :URL "https://github.com/brown/swank-crew.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "swank-client"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/brown/swank-client.git")))
+    :URL "https://github.com/brown/swank-client.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "submarine"
-    :VC "darcs"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/submarine/darcs/submarine/")))
+    :URL "http://common-lisp.net/project/submarine/darcs/submarine/")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "stumpwm"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/stumpwm/stumpwm.git")))
+    :URL "https://github.com/stumpwm/stumpwm.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "stump-touchy-mode-line"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/mabragor/stump-touchy-mode-line.git")))
+    :URL "https://github.com/mabragor/stump-touchy-mode-line.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "stringprep"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/esessoms/stringprep.git")))
+    :URL "https://github.com/esessoms/stringprep.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "string-escape"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://people.csail.mit.edu/devon/lisp/string-escape.tgz")))
+    :URL "http://people.csail.mit.edu/devon/lisp/string-escape.tgz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "string-case"
-    :VC "single-file"
-    :LOCATIONS (("latest" . "http://pvk.ca/string-case.lisp")))
+    :URL "http://pvk.ca/string-case.lisp")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "stp-query"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/esessoms/stp-query.git")))
+    :URL "https://github.com/esessoms/stp-query.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "stmx"
-    :VC "branched-git"
-    :LOCATIONS (("latest" . "https://github.com/cosmos72/stmx.git stable")))
+    :URL "https://github.com/cosmos72/stmx.git stable")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "stem"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/hanshuebner/stem.git")))
+    :URL "https://github.com/hanshuebner/stem.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "stefil"
-    :VC "darcs"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/stefil/darcs/stefil")))
+    :URL "http://common-lisp.net/project/stefil/darcs/stefil")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "static-vectors"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "https://github.com/sionescu/static-vectors/archive/v1.6.tar.gz")))
+    :URL "https://github.com/sionescu/static-vectors/archive/v1.6.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "staple"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Shinmera/staple.git")))
+    :URL "https://github.com/Shinmera/staple.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "st-json"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/marijnh/ST-JSON.git")))
+    :URL "https://github.com/marijnh/ST-JSON.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "squirl"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/zkat/squirl.git")))
+    :URL "https://github.com/zkat/squirl.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "sqnc"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/tlh/sqnc.git")))
+    :URL "https://github.com/tlh/sqnc.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "split-sequence"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "https://github.com/sharplispers/split-sequence/archive/v1.2.tar.gz")))
+    :URL "https://github.com/sharplispers/split-sequence/archive/v1.2.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "spinneret"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/ruricolist/spinneret.git")))
+    :URL "https://github.com/ruricolist/spinneret.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "spellcheck"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/RobBlackwell/spellcheck.git")))
+    :URL "https://github.com/RobBlackwell/spellcheck.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "spatial-trees"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/rpav/spatial-trees.git")))
+    :URL "https://github.com/rpav/spatial-trees.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "spartns"
-    :VC "http"
-    :LOCATIONS (("latest" . "http://aleph0.info/spartns/spartns.tar.gz")))
+    :URL "http://aleph0.info/spartns/spartns.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "south"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Shinmera/south.git")))
+    :URL "https://github.com/Shinmera/south.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "soundex"
-    :VC "http"
-    :LOCATIONS (("latest" . "http://abstractnonsense.com/soundex-1.0.tgz")))
+    :URL "http://abstractnonsense.com/soundex-1.0.tgz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "software-evolution"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/eschulte/software-evolution.git")))
+    :URL "https://github.com/eschulte/software-evolution.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "softdrink"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Shinmera/softdrink.git")))
+    :URL "https://github.com/Shinmera/softdrink.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "snooze"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/capitaomorte/snooze.git")))
+    :URL "https://github.com/capitaomorte/snooze.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "snmp"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/cl-net-snmp/release/snmp_latest.tar.gz")))
+    :URL "http://common-lisp.net/project/cl-net-snmp/release/snmp_latest.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "snappy"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/brown/snappy.git")))
+    :URL "https://github.com/brown/snappy.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "snakes"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/BnMcGn/snakes.git")))
+    :URL "https://github.com/BnMcGn/snakes.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "smug"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/drewc/smug.git")))
+    :URL "https://github.com/drewc/smug.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "smtp4cl"
-    :VC "http-bz2"
-    :LOCATIONS (("latest"
-                 . "http://wcp.sdf-eu.org/software/smtp4cl-latest.tbz")))
+    :URL "http://wcp.sdf-eu.org/software/smtp4cl-latest.tbz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "smackjack"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/aarvid/SmackJack")))
+    :URL "https://github.com/aarvid/SmackJack")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "slime"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "https://common-lisp.net/project/slime/slime_latest.tar.gz")))
+    :URL "https://common-lisp.net/project/slime/slime_latest.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "skippy"
-    :VC "http"
-    :LOCATIONS (("latest" . "http://www.xach.com/lisp/skippy.tgz")))
+    :URL "http://www.xach.com/lisp/skippy.tgz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "sip-hash"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/brown/sip-hash.git")))
+    :URL "https://github.com/brown/sip-hash.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "single-threaded-ccl"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://gitlab.common-lisp.net/qitab/single-threaded-ccl.git")))
+    :URL "https://gitlab.common-lisp.net/qitab/single-threaded-ccl.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "simpsamp"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://www.thoughtcrime.us/software/simpsamp/simpsamp-0.1.tar.gz")))
+    :URL "http://www.thoughtcrime.us/software/simpsamp/simpsamp-0.1.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "simple-tasks"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Shinmera/simple-tasks.git")))
+    :URL "https://github.com/Shinmera/simple-tasks.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "simple-rgb"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/wmannis/simple-rgb")))
+    :URL "https://github.com/wmannis/simple-rgb")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "simple-finalizer"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Balooga/Simple-Finalizer.git")))
+    :URL "https://github.com/Balooga/Simple-Finalizer.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "simple-date-time"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/quek/simple-date-time.git")))
+    :URL "https://github.com/quek/simple-date-time.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "simple-currency"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/a0-prw/simple-currency.git")))
+    :URL "https://github.com/a0-prw/simple-currency.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "shuffletron"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/ahefner/shuffletron.git")))
+    :URL "https://github.com/ahefner/shuffletron.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "should-test"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/vseloved/should-test.git")))
+    :URL "https://github.com/vseloved/should-test.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "shelly"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/fukamachi/shelly.git")))
+    :URL "https://github.com/fukamachi/shelly.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "shellpool"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/jaredcdavis/shellpool.git")))
+    :URL "https://github.com/jaredcdavis/shellpool.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "sheeple"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/zkat/sheeple.git")))
+    :URL "https://github.com/zkat/sheeple.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "shadchen"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/VincentToups/shadchen.git")))
+    :URL "https://github.com/VincentToups/shadchen.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "sha3"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/pmai/sha3.git")))
+    :URL "https://github.com/pmai/sha3.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "sexml"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/madnificent/SEXML.git")))
+    :URL "https://github.com/madnificent/SEXML.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "session-token"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Inaimathi/session-token.git")))
+    :URL "https://github.com/Inaimathi/session-token.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "series"
-    :VC "git"
-    :LOCATIONS (("latest" . "git://git.code.sf.net/p/series/series")))
+    :URL "git://git.code.sf.net/p/series/series")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "serapeum"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/TBRSS/serapeum.git")))
+    :URL "https://github.com/TBRSS/serapeum.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "sequence-iterators"
-    :VC "darcs"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/sequence-iterators/darcs/sequence-iterators/")))
+    :URL "http://common-lisp.net/project/sequence-iterators/darcs/sequence-iterators/")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "secure-random"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/avodonosov/secure-random.git")))
+    :URL "https://github.com/avodonosov/secure-random.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "secret-values"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/copyleft/secret-values.git")))
+    :URL "https://github.com/copyleft/secret-values.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "sdl2kit"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/lispgames/sdl2kit.git")))
+    :URL "https://github.com/lispgames/sdl2kit.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "scriptl"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/rpav/ScriptL.git")))
+    :URL "https://github.com/rpav/ScriptL.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "scribble"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://gitlab.common-lisp.net/frideau/scribble.git")))
+    :URL "https://gitlab.common-lisp.net/frideau/scribble.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "scriba"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/CommonDoc/scriba.git")))
+    :URL "https://github.com/CommonDoc/scriba.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "screamer"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/nikodemus/screamer.git")))
+    :URL "https://github.com/nikodemus/screamer.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "sclf"
-    :VC "http-bz2"
-    :LOCATIONS (("latest" . "http://wcp.sdf-eu.org/software/sclf-latest.tbz")))
+    :URL "http://wcp.sdf-eu.org/software/sclf-latest.tbz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "scalpl"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/adlai/scalpl.git")))
+    :URL "https://github.com/adlai/scalpl.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "sb-vector-io"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/nikodemus/sb-vector-io.git")))
+    :URL "https://github.com/nikodemus/sb-vector-io.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "sb-fastcgi"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/KDr2/sb-fastcgi.git")))
+    :URL "https://github.com/KDr2/sb-fastcgi.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "sb-cga"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/nikodemus/sb-cga.git")))
+    :URL "https://github.com/nikodemus/sb-cga.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "sapaclisp"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/sapaclisp/sapaclisp-1.0a.tgz")))
+    :URL "http://common-lisp.net/project/sapaclisp/sapaclisp-1.0a.tgz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "salza2"
-    :VC "http"
-    :LOCATIONS (("latest" . "http://www.xach.com/lisp/salza2.tgz")))
+    :URL "http://www.xach.com/lisp/salza2.tgz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "s-xml"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://gitlab.common-lisp.net/s-xml/s-xml.git")))
+    :URL "https://gitlab.common-lisp.net/s-xml/s-xml.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "s-xml-rpc"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/s-xml-rpc/s-xml-rpc.tgz")))
+    :URL "http://common-lisp.net/project/s-xml-rpc/s-xml-rpc.tgz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "s-utils"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/svenvc/s-utils.git")))
+    :URL "https://github.com/svenvc/s-utils.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "s-sysdeps"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/svenvc/s-sysdeps.git")))
+    :URL "https://github.com/svenvc/s-sysdeps.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "s-protobuf"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/ndantam/s-protobuf.git")))
+    :URL "https://github.com/ndantam/s-protobuf.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "s-http-server"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/svenvc/s-http-server.git")))
+    :URL "https://github.com/svenvc/s-http-server.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "s-http-client"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/svenvc/s-http-client.git")))
+    :URL "https://github.com/svenvc/s-http-client.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "s-dot"
-    :VC "http"
-    :LOCATIONS (("latest" . "http://martin-loetzsch.de/S-DOT/s-dot.tar.gz")))
+    :URL "http://martin-loetzsch.de/S-DOT/s-dot.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "s-base64"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/svenvc/s-base64.git")))
+    :URL "https://github.com/svenvc/s-base64.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "ryeboy"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/AeroNotix/ryeboy.git")))
+    :URL "https://github.com/AeroNotix/ryeboy.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "rutils"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/vseloved/rutils.git")))
+    :URL "https://github.com/vseloved/rutils.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "rucksack"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://gitlab.common-lisp.net/rucksack/rucksack.git")))
+    :URL "https://gitlab.common-lisp.net/rucksack/rucksack.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "rtm-lisp-api"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://rtm-lisp-api.googlecode.com/files/rtm-lisp-api-v2.tgz")))
- #S(QI.MANIFEST::MANIFEST-PACKAGE :NAME "rt" :VC "kmr-git" :LOCATIONS (("latest" . "rt")))
+    :URL "http://rtm-lisp-api.googlecode.com/files/rtm-lisp-api-v2.tgz")
+ #S(QI.MANIFEST::MANIFEST-PACKAGE
+    :NAME "rt"
+    :URL "rt")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "rpm"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://gitlab.common-lisp.net/qitab/rpm.git")))
+    :URL "https://gitlab.common-lisp.net/qitab/rpm.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "rpc4cl"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/pidu/rpc4cl.git")))
+    :URL "https://github.com/pidu/rpc4cl.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "romreader"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/redline6561/romreader.git")))
+    :URL "https://github.com/redline6561/romreader.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "rock"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/eudoxia0/rock.git")))
- #S(QI.MANIFEST::MANIFEST-PACKAGE :NAME "rlc" :VC "kmr-git" :LOCATIONS (("latest" . "rlc")))
+    :URL "https://github.com/eudoxia0/rock.git")
+ #S(QI.MANIFEST::MANIFEST-PACKAGE :NAME "rlc" :URL "rlc")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "rfc3339-timestamp"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/pidu/rfc3339-timestamp.git")))
+    :URL "https://github.com/pidu/rfc3339-timestamp.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "rfc2388"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/jdz/rfc2388.git")))
+    :URL "https://github.com/jdz/rfc2388.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "rfc2388-binary"
-    :VC "darcs"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/ucw/darcs/rfc2388-binary/")))
+    :URL "http://common-lisp.net/project/ucw/darcs/rfc2388-binary/")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "rfc2109"
-    :VC "darcs"
-    :LOCATIONS (("latest"
-                 . "http://www.common-lisp.net/project/rfc2109/rfc2109/")))
+    :URL "http://www.common-lisp.net/project/rfc2109/rfc2109/")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "reversi"
-    :VC "kmr-git"
-    :LOCATIONS (("latest" . "reversi")))
+    :URL "reversi")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "retrospectiff"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/slyrus/retrospectiff.git")))
+    :URL "https://github.com/slyrus/retrospectiff.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "restful"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Ralt/restful.git")))
+    :URL "https://github.com/Ralt/restful.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "restas"
-    :VC "tagged-git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/archimag/restas.git version-0.1.3")))
+    :URL "https://github.com/archimag/restas.git version-0.1.3")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "restas"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/archimag/restas.git")))
+    :URL "https://github.com/archimag/restas.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "restas.file-publisher"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/kevinlynx/restas.file-publisher.git")))
+    :URL "https://github.com/kevinlynx/restas.file-publisher.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "restas-directory-publisher"
-    :VC "tagged-git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/archimag/restas-directory-publisher.git version-0.1")))
+    :URL "https://github.com/archimag/restas-directory-publisher.git version-0.1")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "restas-directory-publisher"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/archimag/restas-directory-publisher.git")))
+    :URL "https://github.com/archimag/restas-directory-publisher.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "repl-utilities"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/m-n/repl-utilities.git")))
+    :URL "https://github.com/m-n/repl-utilities.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "regex"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/michaelw/regex.git")))
+    :URL "https://github.com/michaelw/regex.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "regex-plugin"
-    :VC "http"
-    :LOCATIONS (("latest" . "http://weitz.de/files/regex-plugin.tar.gz")))
+    :URL "http://weitz.de/files/regex-plugin.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "recursive-regex"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/AccelerationNet/recursive-regex.git")))
+    :URL "https://github.com/AccelerationNet/recursive-regex.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "recur"
-    :VC "mercurial"
-    :LOCATIONS (("latest" . "https://bitbucket.org/tarballs_are_good/recur")))
+    :URL "https://bitbucket.org/tarballs_are_good/recur")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "rectangle-packing"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/woudshoo/rectangle-packing.git")))
+    :URL "https://github.com/woudshoo/rectangle-packing.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "reader-interception"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://gitlab.common-lisp.net/frideau/reader-interception.git")))
+    :URL "https://gitlab.common-lisp.net/frideau/reader-interception.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "readable"
-    :VC "git"
-    :LOCATIONS (("latest" . "git://git.code.sf.net/p/readable/code")))
+    :URL "git://git.code.sf.net/p/readable/code")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "read-csv"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/WarrenWilkinson/read-csv.git")))
+    :URL "https://github.com/WarrenWilkinson/read-csv.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "rcl"
-    :VC "http"
-    :LOCATIONS (("latest" . "https://common-lisp.net/project/rcl/rcl.tar.gz")))
+    :URL "https://common-lisp.net/project/rcl/rcl.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "ratify"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Shinmera/Ratify.git")))
+    :URL "https://github.com/Shinmera/Ratify.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "random"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/brown/random.git")))
+    :URL "https://github.com/brown/random.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "random-access-lists"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/VincentToups/random-access-lists.git")))
+    :URL "https://github.com/VincentToups/random-access-lists.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "racer"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/ha-mo-we/Racer.git")))
+    :URL "https://github.com/ha-mo-we/Racer.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "quux-time"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://gitlab.common-lisp.net/qitab/quux-time.git")))
+    :URL "https://gitlab.common-lisp.net/qitab/quux-time.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "quri"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/fukamachi/quri.git")))
+    :URL "https://github.com/fukamachi/quri.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "quid-pro-quo"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/sellout/quid-pro-quo.git")))
+    :URL "https://github.com/sellout/quid-pro-quo.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "quickutil"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/tarballs-are-good/quickutil.git")))
+    :URL "https://github.com/tarballs-are-good/quickutil.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "quicksearch"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/tkych/quicksearch.git")))
+    :URL "https://github.com/tkych/quicksearch.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "quickproject"
-    :VC "http"
-    :LOCATIONS (("latest" . "http://www.xach.com/lisp/quickproject.tgz")))
+    :URL "http://www.xach.com/lisp/quickproject.tgz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "quicklisp-slime-helper"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/quicklisp/quicklisp-slime-helper.git")))
+    :URL "https://github.com/quicklisp/quicklisp-slime-helper.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "quicklisp-slime-helper"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/quicklisp/quicklisp-slime-helper.git")))
+    :URL "https://github.com/quicklisp/quicklisp-slime-helper.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "quickdocs"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/fukamachi/quickdocs.git")))
+    :URL "https://github.com/fukamachi/quickdocs.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "quickdist"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/orivej/quickdist.git")))
+    :URL "https://github.com/orivej/quickdist.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "quickapp"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/triclops200/quickapp.git")))
+    :URL "https://github.com/triclops200/quickapp.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "queues"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/oconnore/queues.git")))
+    :URL "https://github.com/oconnore/queues.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "query-fs"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/fb08af68/query-fs.git")))
+    :URL "https://github.com/fb08af68/query-fs.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "quasiquote-2.0"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/mabragor/quasiquote-2.0.git")))
+    :URL "https://github.com/mabragor/quasiquote-2.0.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "quadtree"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/takagi/quadtree.git")))
+    :URL "https://github.com/takagi/quadtree.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "qtools"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Shinmera/qtools.git")))
+    :URL "https://github.com/Shinmera/qtools.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "qt-libs"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Shinmera/qt-libs.git")))
+    :URL "https://github.com/Shinmera/qt-libs.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "qooxlisp"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/kennytilton/qooxlisp.git")))
+    :URL "https://github.com/kennytilton/qooxlisp.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "qmynd"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/qitab/qmynd.git")))
+    :URL "https://github.com/qitab/qmynd.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "qlot"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/fukamachi/qlot.git")))
+    :URL "https://github.com/fukamachi/qlot.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "qbook"
-    :VC "darcs"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/bese/repos/qbook/")))
+    :URL "http://common-lisp.net/project/bese/repos/qbook/")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "pzmq"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/orivej/pzmq.git")))
+    :URL "https://github.com/orivej/pzmq.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "pythonic-string-reader"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/smithzvk/pythonic-string-reader.git")))
+    :URL "https://github.com/smithzvk/pythonic-string-reader.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "py-configvalidator"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://gitorious.org/py-configvalidator/py-configvalidator.git")))
+    :URL "https://gitorious.org/py-configvalidator/py-configvalidator.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "py-configvalidator"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/arbscht/py-configvalidator.git")))
+    :URL "https://github.com/arbscht/py-configvalidator.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "py-configparser"
-    :VC "svn"
-    :LOCATIONS (("latest"
-                 . "svn://common-lisp.net/project/py-configparser/svn/trunk")))
+    :URL "svn://common-lisp.net/project/py-configparser/svn/trunk")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "purl"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/eugeneia/purl.git")))
+    :URL "https://github.com/eugeneia/purl.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "puri"
-    :VC "http"
-    :LOCATIONS (("latest" . "http://beta.quicklisp.org/archive/puri/2015-09-23/puri-20150923-git.tgz")))
+    :URL "http://beta.quicklisp.org/archive/puri/2015-09-23/puri-20150923-git.tgz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "ptester"
-    :VC "kmr-git"
-    :LOCATIONS (("latest" . "ptester")))
+    :URL "ptester")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "psgraph"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/asdf-packaging/psgraph-latest.tar.gz")))
+    :URL "http://common-lisp.net/project/asdf-packaging/psgraph-latest.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "prove"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/fukamachi/prove.git")))
+    :URL "https://github.com/fukamachi/prove.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "protobuf"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/brown/protobuf.git")))
+    :URL "https://github.com/brown/protobuf.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "projectured"
-    :VC "branched-git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/projectured/projectured.git quicklisp")))
+    :URL "https://github.com/projectured/projectured.git quicklisp")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "proc-parse"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/fukamachi/proc-parse.git")))
+    :URL "https://github.com/fukamachi/proc-parse.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "priority-queue"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/dsorokin/priority-queue.git")))
+    :URL "https://github.com/dsorokin/priority-queue.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "printv"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/danlentz/printv.git")))
+    :URL "https://github.com/danlentz/printv.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "pretty-function"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/nallen05/pretty-function.git")))
+    :URL "https://github.com/nallen05/pretty-function.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "prepl"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/bluelisp/prepl.git")))
+    :URL "https://github.com/bluelisp/prepl.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "pp-toml"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/pnathan/pp-toml.git")))
+    :URL "https://github.com/pnathan/pp-toml.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "pounds"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/fjames86/pounds.git")))
+    :URL "https://github.com/fjames86/pounds.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "postoffice"
-    :VC "kmr-git"
-    :LOCATIONS (("latest" . "postoffice")))
+    :URL "postoffice")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "postmodern"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/marijnh/Postmodern.git")))
+    :URL "https://github.com/marijnh/Postmodern.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "positional-lambda"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://tarballs.hexstreamsoft.com/libraries/latest/positional-lambda_latest.tar.gz")))
+    :URL "http://tarballs.hexstreamsoft.com/libraries/latest/positional-lambda_latest.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "portableaserve"
-    :VC "git"
-    :LOCATIONS (("latest" . "git://git.code.sf.net/p/portableaserve/git")))
+    :URL "git://git.code.sf.net/p/portableaserve/git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "pooler"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/quasi/pooler.git")))
+    :URL "https://github.com/quasi/pooler.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "policy-cond"
-    :VC "mercurial"
-    :LOCATIONS (("latest"
-                 . "https://bitbucket.org/tarballs_are_good/policy-cond")))
+    :URL "https://bitbucket.org/tarballs_are_good/policy-cond")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "png-read"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Ramarren/png-read.git")))
+    :URL "https://github.com/Ramarren/png-read.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "plump"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Shinmera/plump.git")))
+    :URL "https://github.com/Shinmera/plump.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "plump-tex"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Shinmera/plump-tex.git")))
+    :URL "https://github.com/Shinmera/plump-tex.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "plump-sexp"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Shinmera/plump-sexp.git")))
+    :URL "https://github.com/Shinmera/plump-sexp.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "plump-bundle"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Shinmera/plump-bundle.git")))
+    :URL "https://github.com/Shinmera/plump-bundle.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "plokami"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/atomontage/plokami.git")))
+    :URL "https://github.com/atomontage/plokami.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "plexippus-xpath"
-    :VC "clnet-darcs"
-    :LOCATIONS (("latest" . "plexippus-xpath")))
+    :URL "plexippus-xpath")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "planks"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/drewc/planks.git")))
+    :URL "https://github.com/drewc/planks.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "plain-odbc"
-    :VC "svn"
-    :LOCATIONS (("latest"
-                 . "svn://common-lisp.net/project/plain-odbc/svn/plain-odbc/trunk")))
+    :URL "svn://common-lisp.net/project/plain-odbc/svn/plain-odbc/trunk")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "place-utils"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://tarballs.hexstreamsoft.com/libraries/latest/place-utils_latest.tar.gz")))
+    :URL "http://tarballs.hexstreamsoft.com/libraries/latest/place-utils_latest.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "place-modifiers"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://tarballs.hexstreamsoft.com/libraries/latest/place-modifiers_latest.tar.gz")))
+    :URL "http://tarballs.hexstreamsoft.com/libraries/latest/place-modifiers_latest.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "pithy-xml"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/frodef/pithy-xml.git")))
+    :URL "https://github.com/frodef/pithy-xml.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "piping"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Shinmera/piping.git")))
+    :URL "https://github.com/Shinmera/piping.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "pipes"
-    :VC "kmr-git"
-    :LOCATIONS (("latest" . "pipes")))
+    :URL "pipes")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "pileup"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/nikodemus/pileup.git")))
+    :URL "https://github.com/nikodemus/pileup.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "philip-jose"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://gitlab.common-lisp.net/frideau/philip-jose.git")))
+    :URL "https://gitlab.common-lisp.net/frideau/philip-jose.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "pgloader"
-    :VC "http"
-    :LOCATIONS (("latest" . "http://pgloader.io/pgloader-latest.tgz")))
+    :URL "http://pgloader.io/pgloader-latest.tgz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "pg"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://gitlab.common-lisp.net/pg/pg.git")))
+    :URL "https://gitlab.common-lisp.net/pg/pg.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "pettomato-indexed-priority-queue"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/austinhaas/pettomato-indexed-priority-queue.git")))
+    :URL "https://github.com/austinhaas/pettomato-indexed-priority-queue.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "pettomato-deque"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/austinhaas/pettomato-deque.git")))
+    :URL "https://github.com/austinhaas/pettomato-deque.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "petit.string-utils"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/ichimal/petit.string-utils.git")))
+    :URL "https://github.com/ichimal/petit.string-utils.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "petit.package-utils"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/ichimal/petit.package-utils.git")))
+    :URL "https://github.com/ichimal/petit.package-utils.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "persistent-variables"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/WarrenWilkinson/persistent-variables.git")))
+    :URL "https://github.com/WarrenWilkinson/persistent-variables.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "persistent-tables"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/VincentToups/persistent-tables.git")))
+    :URL "https://github.com/VincentToups/persistent-tables.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "perlre"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/jschatzer/perlre.git")))
+    :URL "https://github.com/jschatzer/perlre.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "perl-in-lisp"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://stuartsierra.com/download/perl-in-lisp_0.1.tar.gz")))
+    :URL "http://stuartsierra.com/download/perl-in-lisp_0.1.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "periods"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/jwiegley/periods.git")))
+    :URL "https://github.com/jwiegley/periods.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "periodic-table"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/chemboy/periodic-table-latest.tar.gz")))
+    :URL "http://common-lisp.net/project/chemboy/periodic-table-latest.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "perfpiece"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/luismbo/perfpiece.git")))
+    :URL "https://github.com/luismbo/perfpiece.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "percent-encoding"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/llibra/percent-encoding.git")))
+    :URL "https://github.com/llibra/percent-encoding.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "pcall"
-    :VC "http"
-    :LOCATIONS (("latest" . "http://marijnhaverbeke.nl/pcall/pcall.tgz")))
+    :URL "http://marijnhaverbeke.nl/pcall/pcall.tgz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "patron"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/vy/patron.git")))
+    :URL "https://github.com/vy/patron.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "parseltongue"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/VincentToups/parseltongue.git")))
+    :URL "https://github.com/VincentToups/parseltongue.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "parse-number"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "https://github.com/sharplispers/parse-number/archive/v1.4.tar.gz")))
+    :URL "https://github.com/sharplispers/parse-number/archive/v1.4.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "parse-number-range"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://tarballs.hexstreamsoft.com/libraries/latest/parse-number-range_latest.tar.gz")))
+    :URL "http://tarballs.hexstreamsoft.com/libraries/latest/parse-number-range_latest.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "parse-js"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/marijnh/parse-js.git")))
+    :URL "https://github.com/marijnh/parse-js.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "parse-float"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/soemraws/parse-float.git")))
+    :URL "https://github.com/soemraws/parse-float.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "parse-declarations"
-    :VC "darcs"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/parse-declarations/darcs/parse-declarations")))
+    :URL "http://common-lisp.net/project/parse-declarations/darcs/parse-declarations")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "parenscript"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/parenscript/release/parenscript-latest.tgz")))
+    :URL "http://common-lisp.net/project/parenscript/release/parenscript-latest.tgz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "parenscript-classic"
-    :VC "darcs"
-    :LOCATIONS (("latest"
-                 . "http://darcs.unknownlamer.org/parenscript-classic")))
+    :URL "http://darcs.unknownlamer.org/parenscript-classic")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "paren-util"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/gonzojive/paren-util.git")))
+    :URL "https://github.com/gonzojive/paren-util.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "paren-test"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/gonzojive/paren-test.git")))
+    :URL "https://github.com/gonzojive/paren-test.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "paren-psos"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/gonzojive/paren-psos.git")))
+    :URL "https://github.com/gonzojive/paren-psos.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "paren-files"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/gonzojive/paren-files.git")))
+    :URL "https://github.com/gonzojive/paren-files.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "paren-events"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/gonzojive/paren-events.git")))
+    :URL "https://github.com/gonzojive/paren-events.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "parameterized-function"
-    :VC "mercurial"
-    :LOCATIONS (("latest"
-                 . "https://bitbucket.org/tarballs_are_good/parameterized-function")))
+    :URL "https://bitbucket.org/tarballs_are_good/parameterized-function")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "pal"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://gitlab.common-lisp.net/pal/pal.git")))
+    :URL "https://gitlab.common-lisp.net/pal/pal.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "paiprolog"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/quek/paiprolog.git")))
+    :URL "https://github.com/quek/paiprolog.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "packet"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/fjames86/packet.git")))
+    :URL "https://github.com/fjames86/packet.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "package-renaming"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://gitlab.common-lisp.net/frideau/package-renaming.git")))
+    :URL "https://gitlab.common-lisp.net/frideau/package-renaming.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "pack"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/soemraws/pack.git")))
+    :URL "https://github.com/soemraws/pack.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "osicat"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/osicat/osicat.git")))
+    :URL "https://github.com/osicat/osicat.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "osc"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/zzkt/osc.git")))
+    :URL "https://github.com/zzkt/osc.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "org-davep-dictrepl"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/davep/org-davep-dictrepl.git")))
+    :URL "https://github.com/davep/org-davep-dictrepl.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "org-davep-dict"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/davep/org-davep-dict.git")))
+    :URL "https://github.com/davep/org-davep-dict.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "optima"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/m2ym/optima.git")))
+    :URL "https://github.com/m2ym/optima.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "opticl"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/slyrus/opticl.git")))
+    :URL "https://github.com/slyrus/opticl.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "open-vrp"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/mck-/Open-VRP.git")))
+    :URL "https://github.com/mck-/Open-VRP.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "oneliner"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/mck-/oneliner.git")))
+    :URL "https://github.com/mck-/oneliner.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "oe-encode"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/mtstickney/oe-encode.git")))
+    :URL "https://github.com/mtstickney/oe-encode.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "ods4cl"
-    :VC "http-bz2"
-    :LOCATIONS (("latest"
-                 . "http://wcp.sdf-eu.org/software/ods4cl-latest.tbz")))
+    :URL "http://wcp.sdf-eu.org/software/ods4cl-latest.tbz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "odd-streams"
-    :VC "http"
-    :LOCATIONS (("latest" . "http://weitz.de/files/odd-streams.tar.gz")))
+    :URL "http://weitz.de/files/odd-streams.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "nuclblog"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/slyrus/nuclblog.git")))
+    :URL "https://github.com/slyrus/nuclblog.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "nst"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://nst.maraist.org/download/nst-latest.tar.gz")))
+    :URL "http://nst.maraist.org/download/nst-latest.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "nsort"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/jschatzer/nsort.git")))
+    :URL "https://github.com/jschatzer/nsort.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "npg"
-    :VC "http-bz2"
-    :LOCATIONS (("latest" . "http://wcp.sdf-eu.org/software/npg-latest.tbz")))
+    :URL "http://wcp.sdf-eu.org/software/npg-latest.tbz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "ningle"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/fukamachi/ningle.git")))
+    :URL "https://github.com/fukamachi/ningle.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "nibbles"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/froydnj/nibbles.git")))
+    :URL "https://github.com/froydnj/nibbles.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "new-op"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://gitlab.common-lisp.net/new-op/new-op.git")))
+    :URL "https://gitlab.common-lisp.net/new-op/new-op.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "net4cl"
-    :VC "http-bz2"
-    :LOCATIONS (("latest"
-                 . "http://wcp.sdf-eu.org/software/net4cl-latest.tbz")))
+    :URL "http://wcp.sdf-eu.org/software/net4cl-latest.tbz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "net-telent-date"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://ftp.linux.org.uk/pub/lisp/cclan/net-telent-date.tar.gz")))
+    :URL "http://ftp.linux.org.uk/pub/lisp/cclan/net-telent-date.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "napa-fft3"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/pkhuong/Napa-FFT3.git")))
+    :URL "https://github.com/pkhuong/Napa-FFT3.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "named-readtables"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/melisgl/named-readtables.git")))
+    :URL "https://github.com/melisgl/named-readtables.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "myweb"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/troydm/myweb.git")))
+    :URL "https://github.com/troydm/myweb.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "myway"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/fukamachi/myway.git")))
+    :URL "https://github.com/fukamachi/myway.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "mw-equiv"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://www.foldr.org/~michaelw/projects/mw-equiv/mw-equiv.tar.gz")))
+    :URL "http://www.foldr.org/~michaelw/projects/mw-equiv/mw-equiv.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "multival-plist"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/fukamachi/multival-plist.git")))
+    :URL "https://github.com/fukamachi/multival-plist.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "multiple-value-variants"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://tarballs.hexstreamsoft.com/libraries/latest/multiple-value-variants_latest.tar.gz")))
+    :URL "http://tarballs.hexstreamsoft.com/libraries/latest/multiple-value-variants_latest.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "mtlisp"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/mtravers/mtlisp.git")))
+    :URL "https://github.com/mtravers/mtlisp.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "mt19937"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/asdf-packaging/mt19937-latest.tar.gz")))
+    :URL "http://common-lisp.net/project/asdf-packaging/mt19937-latest.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "mpc"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/eugeneia/mpc.git")))
+    :URL "https://github.com/eugeneia/mpc.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "more-conditions"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/scymtym/more-conditions.git")))
+    :URL "https://github.com/scymtym/more-conditions.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "moptilities"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/gwkkwg/moptilities.git")))
+    :URL "https://github.com/gwkkwg/moptilities.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "mop-utils"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/submarine/mop-utils.tar.gz")))
+    :URL "http://common-lisp.net/project/submarine/mop-utils.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "montezuma"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/sharplispers/montezuma.git")))
+    :URL "https://github.com/sharplispers/montezuma.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "monkeylib-utilities"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/gigamonkey/monkeylib-utilities.git")))
+    :URL "https://github.com/gigamonkey/monkeylib-utilities.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "monkeylib-text-output"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/gigamonkey/monkeylib-text-output.git")))
+    :URL "https://github.com/gigamonkey/monkeylib-text-output.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "monkeylib-text-languages"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/gigamonkey/monkeylib-text-languages.git")))
+    :URL "https://github.com/gigamonkey/monkeylib-text-languages.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "monkeylib-test-framework"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/gigamonkey/monkeylib-test-framework.git")))
+    :URL "https://github.com/gigamonkey/monkeylib-test-framework.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "monkeylib-prose-diff"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/gigamonkey/monkeylib-prose-diff.git")))
+    :URL "https://github.com/gigamonkey/monkeylib-prose-diff.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "monkeylib-pathnames"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/gigamonkey/monkeylib-pathnames.git")))
+    :URL "https://github.com/gigamonkey/monkeylib-pathnames.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "monkeylib-parser"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/gigamonkey/monkeylib-parser.git")))
+    :URL "https://github.com/gigamonkey/monkeylib-parser.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "monkeylib-markup"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/gigamonkey/monkeylib-markup.git")))
+    :URL "https://github.com/gigamonkey/monkeylib-markup.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "monkeylib-markup-xml"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/gigamonkey/monkeylib-markup-xml.git")))
+    :URL "https://github.com/gigamonkey/monkeylib-markup-xml.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "monkeylib-markup-html"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/gigamonkey/monkeylib-markup-html.git")))
+    :URL "https://github.com/gigamonkey/monkeylib-markup-html.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "monkeylib-macro-utilities"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/gigamonkey/monkeylib-macro-utilities.git")))
+    :URL "https://github.com/gigamonkey/monkeylib-macro-utilities.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "monkeylib-json"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/gigamonkey/monkeylib-json.git")))
+    :URL "https://github.com/gigamonkey/monkeylib-json.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "monkeylib-html"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/gigamonkey/monkeylib-html.git")))
+    :URL "https://github.com/gigamonkey/monkeylib-html.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "monkeylib-binary-data"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/gigamonkey/monkeylib-binary-data.git")))
+    :URL "https://github.com/gigamonkey/monkeylib-binary-data.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "monkeylib-bcrypt"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/gigamonkey/monkeylib-bcrypt.git")))
+    :URL "https://github.com/gigamonkey/monkeylib-bcrypt.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "modularize"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Shinmera/modularize.git")))
+    :URL "https://github.com/Shinmera/modularize.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "modularize-interfaces"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/Shinmera/modularize-interfaces.git")))
+    :URL "https://github.com/Shinmera/modularize-interfaces.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "modularize-hooks"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/Shinmera/modularize-hooks.git")))
+    :URL "https://github.com/Shinmera/modularize-hooks.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "modf"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/smithzvk/modf.git")))
+    :URL "https://github.com/smithzvk/modf.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "modf-fset"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/smithzvk/modf-fset.git")))
+    :URL "https://github.com/smithzvk/modf-fset.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "mk-string-metrics"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/mrkkrp/mk-string-metrics.git")))
+    :URL "https://github.com/mrkkrp/mk-string-metrics.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "mixalot"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/ahefner/mixalot.git")))
+    :URL "https://github.com/ahefner/mixalot.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "misc-extensions"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://gitlab.common-lisp.net/misc-extensions/devel.git")))
+    :URL "https://gitlab.common-lisp.net/misc-extensions/devel.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "mini-cas"
-    :VC "git"
-    :LOCATIONS (("latest" . "http://git.tentpost.com/git/lisp/mini-cas.git")))
+    :URL "http://git.tentpost.com/git/lisp/mini-cas.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "minheap"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/sfrank/minheap.git")))
+    :URL "https://github.com/sfrank/minheap.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "mime4cl"
-    :VC "http-bz2"
-    :LOCATIONS (("latest"
-                 . "http://wcp.sdf-eu.org/software/mime4cl-latest.tbz")))
+    :URL "http://wcp.sdf-eu.org/software/mime4cl-latest.tbz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "midi"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://www.doc.gold.ac.uk/isms/lisp/midi/midi-20070618.tar.gz")))
+    :URL "http://www.doc.gold.ac.uk/isms/lisp/midi/midi-20070618.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "micmac"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/melisgl/micmac.git")))
+    :URL "https://github.com/melisgl/micmac.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "mgl"
-    :VC "branched-git"
-    :LOCATIONS (("latest" . "https://github.com/melisgl/mgl.git pre-cuda")))
+    :URL "https://github.com/melisgl/mgl.git pre-cuda")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "mgl-pax"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/melisgl/mgl-pax.git")))
+    :URL "https://github.com/melisgl/mgl-pax.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "mexpr"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/tmccombs/mexpr.git")))
+    :URL "https://github.com/tmccombs/mexpr.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "method-versions"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://nklein.com/wp-content/uploads/2011/05/method-versions_0.1.2011.05.18.tar.gz")))
+    :URL "http://nklein.com/wp-content/uploads/2011/05/method-versions_0.1.2011.05.18.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "method-combination-utilities"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/sellout/method-combination-utilities.git")))
+    :URL "https://github.com/sellout/method-combination-utilities.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "metatilities"
-    :VC "darcs"
-    :LOCATIONS (("latest" . "http://common-lisp.net/project/metatilities")))
+    :URL "http://common-lisp.net/project/metatilities")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "metatilities-base"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/gwkkwg/metatilities-base.git")))
+    :URL "https://github.com/gwkkwg/metatilities-base.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "metap"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/hipeta/metap.git")))
+    :URL "https://github.com/hipeta/metap.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "metafs"
-    :VC "http-bz2"
-    :LOCATIONS (("latest"
-                 . "http://wcp.sdf-eu.org/software/metafs-latest.tbz")))
+    :URL "http://wcp.sdf-eu.org/software/metafs-latest.tbz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "metacopy"
-    :VC "darcs"
-    :LOCATIONS (("latest" . "http://dwim.hu/live/metacopy/")))
+    :URL "http://dwim.hu/live/metacopy/")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "metabang-bind"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/gwkkwg/metabang-bind.git")))
+    :URL "https://github.com/gwkkwg/metabang-bind.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "meta"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://gitlab.common-lisp.net/frideau/meta.git")))
+    :URL "https://gitlab.common-lisp.net/frideau/meta.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "meta-sexp"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://www.students.itu.edu.tr/~yazicivo/files/meta-sexp.tar.gz")))
+    :URL "http://www.students.itu.edu.tr/~yazicivo/files/meta-sexp.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "message-oo"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Kalimehtar/message-oo.git")))
+    :URL "https://github.com/Kalimehtar/message-oo.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "memoize"
-    :VC "single-file"
-    :LOCATIONS (("latest" . "http://www.tfeb.org/programs/lisp/memoize.lisp")))
+    :URL "http://www.tfeb.org/programs/lisp/memoize.lisp")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "memoize"
-    :VC "single-file"
-    :LOCATIONS (("latest"
-                 . "http://beta.quicklisp.org/orphans/tfeb/memoize.lisp")))
+    :URL "http://beta.quicklisp.org/orphans/tfeb/memoize.lisp")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "mel-base"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/neonsquare/mel-base.git")))
+    :URL "https://github.com/neonsquare/mel-base.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "media-types"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/TBRSS/media-types.git")))
+    :URL "https://github.com/TBRSS/media-types.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "md5"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/pmai/md5.git")))
+    :URL "https://github.com/pmai/md5.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "mcclim"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/robert-strandh/McCLIM")))
+    :URL "https://github.com/robert-strandh/McCLIM")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "matlisp"
-    :VC "git"
-    :LOCATIONS (("latest" . "git://git.code.sf.net/p/matlisp/git")))
+    :URL "git://git.code.sf.net/p/matlisp/git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "mathkit"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/lispgames/mathkit.git")))
+    :URL "https://github.com/lispgames/mathkit.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "marshal"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/kaiserprogrammer/marshal.git")))
+    :URL "https://github.com/kaiserprogrammer/marshal.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "marching-cubes"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/takagi/marching-cubes.git")))
+    :URL "https://github.com/takagi/marching-cubes.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "map-set"
-    :VC "mercurial"
-    :LOCATIONS (("latest"
-                 . "https://bitbucket.org/tarballs_are_good/map-set")))
+    :URL "https://bitbucket.org/tarballs_are_good/map-set")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "map-bind"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://tarballs.hexstreamsoft.com/libraries/latest/map-bind_latest.tar.gz")))
+    :URL "http://tarballs.hexstreamsoft.com/libraries/latest/map-bind_latest.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "manifest"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/gigamonkey/manifest.git")))
+    :URL "https://github.com/gigamonkey/manifest.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "manardb"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/ilitirit/manardb.git")))
+    :URL "https://github.com/ilitirit/manardb.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "make-hash"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/genovese/make-hash.git")))
+    :URL "https://github.com/genovese/make-hash.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "mailbox"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/drurowin/mailbox.git")))
+    :URL "https://github.com/drurowin/mailbox.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "magicffi"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/dochang/magicffi.git")))
+    :URL "https://github.com/dochang/magicffi.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "madeira-port"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/nikodemus/madeira-port.git")))
+    :URL "https://github.com/nikodemus/madeira-port.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "macroexpand-dammit"
-    :VC "single-file"
-    :LOCATIONS (("latest"
-                 . "http://john.freml.in/static-blog/macroexpand-dammit/macroexpand-dammit.lisp")))
+    :URL "http://john.freml.in/static-blog/macroexpand-dammit/macroexpand-dammit.lisp")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "macrodynamics"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/DalekBaldwin/macrodynamics.git")))
+    :URL "https://github.com/DalekBaldwin/macrodynamics.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "macro-level"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://tarballs.hexstreamsoft.com/libraries/latest/macro-level_latest.tar.gz")))
+    :URL "http://tarballs.hexstreamsoft.com/libraries/latest/macro-level_latest.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "macro-html"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/eugeneia/macro-html.git")))
+    :URL "https://github.com/eugeneia/macro-html.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "m2cl"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/galdor/m2cl.git")))
+    :URL "https://github.com/galdor/m2cl.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "lw-win"
-    :VC "http"
-    :LOCATIONS (("latest" . "http://weitz.de/files/lw-win.tar.gz")))
+    :URL "http://weitz.de/files/lw-win.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "lw-doc"
-    :VC "http"
-    :LOCATIONS (("latest" . "http://weitz.de/files/lw-doc.tar.gz")))
+    :URL "http://weitz.de/files/lw-doc.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "lw-compat"
-    :VC "git"
-    :LOCATIONS (("latest" . "git://git.code.sf.net/p/closer/lw-compat")))
+    :URL "git://git.code.sf.net/p/closer/lw-compat")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "lw-add-ons"
-    :VC "http"
-    :LOCATIONS (("latest" . "http://weitz.de/files/lw-add-ons.tar.gz")))
+    :URL "http://weitz.de/files/lw-add-ons.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "lucerne"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/eudoxia0/lucerne.git")))
+    :URL "https://github.com/eudoxia0/lucerne.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "ltk"
-    :VC "http"
-    :LOCATIONS (("latest" . "http://www.peter-herth.de/ltk/ltk-0.981.tgz")))
+    :URL "http://www.peter-herth.de/ltk/ltk-0.981.tgz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "lredis"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/death/lredis.git")))
+    :URL "https://github.com/death/lredis.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "lquery"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Shinmera/lquery.git")))
+    :URL "https://github.com/Shinmera/lquery.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "lparallel"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/lmj/lparallel.git")))
+    :URL "https://github.com/lmj/lparallel.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "lowlight"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/chfin/lowlight.git")))
+    :URL "https://github.com/chfin/lowlight.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "lol-re"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/mabragor/lol-re.git")))
+    :URL "https://github.com/mabragor/lol-re.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "log5"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/gwkkwg/log5.git")))
+    :URL "https://github.com/gwkkwg/log5.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "log4cl"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/7max/log4cl.git")))
+    :URL "https://github.com/7max/log4cl.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "log4cl"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/sharplispers/log4cl.git")))
+    :URL "https://github.com/sharplispers/log4cl.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "local-time"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/dlowe-net/local-time.git")))
+    :URL "https://github.com/dlowe-net/local-time.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "local-time-duration"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/enaeher/local-time-duration.git")))
+    :URL "https://github.com/enaeher/local-time-duration.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "local-package-aliases"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/avodonosov/local-package-aliases.git")))
+    :URL "https://github.com/avodonosov/local-package-aliases.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "lml2"
-    :VC "kmr-git"
-    :LOCATIONS (("latest" . "lml2")))
- #S(QI.MANIFEST::MANIFEST-PACKAGE :NAME "lml" :VC "kmr-git" :LOCATIONS (("latest" . "lml")))
+    :URL "lml2")
+ #S(QI.MANIFEST::MANIFEST-PACKAGE :NAME "lml" :URL "lml")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "lla"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/tpapp/lla.git")))
+    :URL "https://github.com/tpapp/lla.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "listoflist"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/blindglobe/listoflist.git")))
+    :URL "https://github.com/blindglobe/listoflist.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "lispbuilder"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/lispbuilder/lispbuilder.git")))
+    :URL "https://github.com/lispbuilder/lispbuilder.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "lisp-zmq"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://wandrian.net/download/lisp-zmq-1.5.0.tgz")))
+    :URL "http://wandrian.net/download/lisp-zmq-1.5.0.tgz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "lisp-unit2"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/AccelerationNet/lisp-unit2.git")))
+    :URL "https://github.com/AccelerationNet/lisp-unit2.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "lisp-unit"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/OdonataResearchLLC/lisp-unit.git")))
+    :URL "https://github.com/OdonataResearchLLC/lisp-unit.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "lisp-namespace"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/guicho271828/lisp-namespace.git")))
+    :URL "https://github.com/guicho271828/lisp-namespace.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "lisp-matrix"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/blindglobe/lisp-matrix.git")))
+    :URL "https://github.com/blindglobe/lisp-matrix.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "lisp-magick"
-    :VC "http"
-    :LOCATIONS (("latest" . "http://www.nil.at/download/lisp-magick.tar.gz")))
+    :URL "http://www.nil.at/download/lisp-magick.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "lisp-invocation"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://gitlab.common-lisp.net/qitab/lisp-invocation.git")))
+    :URL "https://gitlab.common-lisp.net/qitab/lisp-invocation.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "lisp-interface-library"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/fare/lisp-interface-library.git")))
+    :URL "https://github.com/fare/lisp-interface-library.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "lisp-gflags"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/brown/lisp-gflags.git")))
+    :URL "https://github.com/brown/lisp-gflags.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "lisp-executable"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/markcox80/lisp-executable.git")))
+    :URL "https://github.com/markcox80/lisp-executable.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "lisa"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/johanlindberg/lisa.git")))
+    :URL "https://github.com/johanlindberg/lisa.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "lisa"
-    :VC "cvs"
-    :LOCATIONS (("latest"
-                 . ":pserver:anonymous@lisa.cvs.sourceforge.net:/cvsroot/lisa")))
+    :URL ":pserver:anonymous@lisa.cvs.sourceforge.net:/cvsroot/lisa")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "linewise-template"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/agrostis/linewise-template.git")))
+    :URL "https://github.com/agrostis/linewise-template.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "linedit"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://gitlab.common-lisp.net/linedit/linedit.git")))
+    :URL "https://gitlab.common-lisp.net/linedit/linedit.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "lime"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/eudoxia0/lime.git")))
+    :URL "https://github.com/eudoxia0/lime.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "lift"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/gwkkwg/lift")))
+    :URL "https://github.com/gwkkwg/lift")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "lhstats"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/mrc/lhstats.git")))
+    :URL "https://github.com/mrc/lhstats.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "lfarm"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/lmj/lfarm.git")))
+    :URL "https://github.com/lmj/lfarm.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "levenshtein"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://abstractnonsense.com/levenshtein-1.0.tgz")))
+    :URL "http://abstractnonsense.com/levenshtein-1.0.tgz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "leveldb"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/death/leveldb.git")))
+    :URL "https://github.com/death/leveldb.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "lev"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/fukamachi/lev.git")))
+    :URL "https://github.com/fukamachi/lev.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "letrec"
-    :VC "mercurial"
-    :LOCATIONS (("latest" . "https://bitbucket.org/tarballs_are_good/letrec")))
+    :URL "https://bitbucket.org/tarballs_are_good/letrec")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "let-plus"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/tpapp/let-plus.git")))
+    :URL "https://github.com/tpapp/let-plus.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "let-over-lambda"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/thephoeron/let-over-lambda.git")))
+    :URL "https://github.com/thephoeron/let-over-lambda.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "legion"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/fukamachi/legion.git")))
+    :URL "https://github.com/fukamachi/legion.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "latex-table"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/tpapp/latex-table.git")))
+    :URL "https://github.com/tpapp/latex-table.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "lassie"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/melisgl/lassie.git")))
+    :URL "https://github.com/melisgl/lassie.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "lass"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Shinmera/LASS.git")))
+    :URL "https://github.com/Shinmera/LASS.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "lambdalite"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Wukix/LambdaLite.git")))
+    :URL "https://github.com/Wukix/LambdaLite.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "lambda-reader"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://gitlab.common-lisp.net/frideau/lambda-reader.git")))
+    :URL "https://gitlab.common-lisp.net/frideau/lambda-reader.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "lambda-gtk"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://gitlab.common-lisp.net/lambda-gtk/lambda-gtk.git")))
+    :URL "https://gitlab.common-lisp.net/lambda-gtk/lambda-gtk.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "lambda-fiddle"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Shinmera/lambda-fiddle.git")))
+    :URL "https://github.com/Shinmera/lambda-fiddle.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "lake"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/takagi/lake.git")))
+    :URL "https://github.com/takagi/lake.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "lack"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/fukamachi/lack.git")))
+    :URL "https://github.com/fukamachi/lack.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "l-math"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/TheRiver/L-MATH.git")))
+    :URL "https://github.com/TheRiver/L-MATH.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "kmrcl"
-    :VC "kmr-git"
-    :LOCATIONS (("latest" . "kmrcl")))
+    :URL "kmrcl")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "km"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://www.cs.utexas.edu/users/mfkb/km/km-latest.tgz")))
+    :URL "http://www.cs.utexas.edu/users/mfkb/km/km-latest.tgz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "kl-verify"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/kevinlynx/kl-verify.git")))
+    :URL "https://github.com/kevinlynx/kl-verify.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "kenzo"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/gheber/kenzo.git")))
+    :URL "https://github.com/gheber/kenzo.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "kebab"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/pocket7878/kebab.git")))
+    :URL "https://github.com/pocket7878/kebab.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "jwacs"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/chumsley/jwacs.git")))
+    :URL "https://github.com/chumsley/jwacs.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "jsown"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/madnificent/jsown.git")))
+    :URL "https://github.com/madnificent/jsown.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "json-streams"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/copyleft/json-streams.git")))
+    :URL "https://github.com/copyleft/json-streams.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "json-responses"
-    :VC "mercurial"
-    :LOCATIONS (("latest" . "https://bitbucket.org/bradJM/json-responses")))
+    :URL "https://bitbucket.org/bradJM/json-responses")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "js"
-    :VC "tagged-git"
-    :LOCATIONS (("latest" . "https://github.com/akapav/js.git v0.12.01")))
+    :URL "https://github.com/akapav/js.git v0.12.01")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "js-parser"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/gonzojive/js-parser")))
+    :URL "https://github.com/gonzojive/js-parser")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "jpl-queues"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://www.thoughtcrime.us/software/jpl-queues/jpl-queues-0.1.tar.gz")))
+    :URL "http://www.thoughtcrime.us/software/jpl-queues/jpl-queues-0.1.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "jp-numeral"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/y2q-actionman/jp-numeral.git")))
+    :URL "https://github.com/y2q-actionman/jp-numeral.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "jonathan"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Rudolph-Miller/jonathan.git")))
+    :URL "https://github.com/Rudolph-Miller/jonathan.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "jenkins"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/scymtym/jenkins.git")))
+    :URL "https://github.com/scymtym/jenkins.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "iterate"
-    :VC "clnet-darcs"
-    :LOCATIONS (("latest" . "iterate")))
+    :URL "iterate")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "iterate-clsql"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/iterate-clsql/releases/iterate-clsql-0.2.tar.gz")))
+    :URL "http://common-lisp.net/project/iterate-clsql/releases/iterate-clsql-0.2.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "ironclad"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/froydnj/ironclad")))
+    :URL "https://github.com/froydnj/ironclad")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "irc-logger"
-    :VC "kmr-git"
-    :LOCATIONS (("latest" . "irc-logger")))
+    :URL "irc-logger")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "ip-interfaces"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "https://common-lisp.net/project/ip-interfaces/releases/ip-interfaces-latest.tar.gz")))
+    :URL "https://common-lisp.net/project/ip-interfaces/releases/ip-interfaces-latest.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "iolib"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/sionescu/iolib.git")))
+    :URL "https://github.com/sionescu/iolib.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "introspect-environment"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/Bike/introspect-environment.git")))
+    :URL "https://github.com/Bike/introspect-environment.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "interface"
-    :VC "mercurial"
-    :LOCATIONS (("latest"
-                 . "https://bitbucket.org/tarballs_are_good/interface")))
+    :URL "https://bitbucket.org/tarballs_are_good/interface")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "intercom"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/madnificent/intercom.git")))
+    :URL "https://github.com/madnificent/intercom.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "intel-hex"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/takagi/intel-hex.git")))
+    :URL "https://github.com/takagi/intel-hex.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "integral"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/fukamachi/integral.git")))
+    :URL "https://github.com/fukamachi/integral.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "integral-rest"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/Rudolph-Miller/integral-rest.git")))
+    :URL "https://github.com/Rudolph-Miller/integral-rest.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "inquisitor"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/t-sin/inquisitor.git")))
+    :URL "https://github.com/t-sin/inquisitor.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "inotify"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/stassats/inotify.git")))
+    :URL "https://github.com/stassats/inotify.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "inner-conditional"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/guicho271828/inner-conditional.git")))
+    :URL "https://github.com/guicho271828/inner-conditional.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "infix-dollar-reader"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/ichimal/infix-dollar-reader.git")))
+    :URL "https://github.com/ichimal/infix-dollar-reader.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "inferior-shell"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://gitlab.common-lisp.net/qitab/inferior-shell.git")))
+    :URL "https://gitlab.common-lisp.net/qitab/inferior-shell.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "incongruent-methods"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/pve1/incongruent-methods.git")))
+    :URL "https://github.com/pve1/incongruent-methods.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "incognito-keywords"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://tarballs.hexstreamsoft.com/libraries/latest/incognito-keywords_latest.tar.gz")))
+    :URL "http://tarballs.hexstreamsoft.com/libraries/latest/incognito-keywords_latest.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "incf-cl"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/jmbr/incf-cl.git")))
+    :URL "https://github.com/jmbr/incf-cl.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "immutable-struct"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/guicho271828/immutable-struct.git")))
+    :URL "https://github.com/guicho271828/immutable-struct.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "imago"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://gitlab.common-lisp.net/imago/imago.git")))
+    :URL "https://gitlab.common-lisp.net/imago/imago.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "image"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/kevinlynx/image.git")))
+    :URL "https://github.com/kevinlynx/image.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "ieee-floats"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/marijnh/ieee-floats.git")))
+    :URL "https://github.com/marijnh/ieee-floats.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "ie3fp"
-    :VC "http-bz2"
-    :LOCATIONS (("latest"
-                 . "http://wcp.sdf-eu.org/software/ie3fp-latest.tbz")))
+    :URL "http://wcp.sdf-eu.org/software/ie3fp-latest.tbz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "idna"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/antifuchs/idna")))
+    :URL "https://github.com/antifuchs/idna")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "hyperobject"
-    :VC "kmr-git"
-    :LOCATIONS (("latest" . "hyperobject")))
+    :URL "hyperobject")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "hyperluminal-mem"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/cosmos72/hyperluminal-mem.git")))
+    :URL "https://github.com/cosmos72/hyperluminal-mem.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "hunchentoot"
-    :VC "http"
-    :LOCATIONS (("latest" . "http://weitz.de/files/hunchentoot.tar.gz")))
+    :URL "http://weitz.de/files/hunchentoot.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "hunchentoot-single-signon"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/lokedhs/hunchentoot-single-signon.git")))
+    :URL "https://github.com/lokedhs/hunchentoot-single-signon.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "hunchentoot-cgi"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/slyrus/hunchentoot-cgi.git")))
+    :URL "https://github.com/slyrus/hunchentoot-cgi.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "hunchentoot-auth"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/slyrus/hunchentoot-auth.git")))
+    :URL "https://github.com/slyrus/hunchentoot-auth.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "hunchensocket"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/capitaomorte/hunchensocket.git")))
+    :URL "https://github.com/capitaomorte/hunchensocket.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "humbler"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Shinmera/humbler.git")))
+    :URL "https://github.com/Shinmera/humbler.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "hu.dwim.web-server"
-    :VC "darcs"
-    :LOCATIONS (("latest" . "http://dwim.hu/live/hu.dwim.web-server/")))
+    :URL "http://dwim.hu/live/hu.dwim.web-server/")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "hu.dwim.walker"
-    :VC "darcs"
-    :LOCATIONS (("latest" . "http://dwim.hu/live/hu.dwim.walker/")))
+    :URL "http://dwim.hu/live/hu.dwim.walker/")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "hu.dwim.util"
-    :VC "darcs"
-    :LOCATIONS (("latest" . "http://dwim.hu/live/hu.dwim.util/")))
+    :URL "http://dwim.hu/live/hu.dwim.util/")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "hu.dwim.uri"
-    :VC "darcs"
-    :LOCATIONS (("latest" . "http://dwim.hu/live/hu.dwim.uri/")))
+    :URL "http://dwim.hu/live/hu.dwim.uri/")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "hu.dwim.syntax-sugar"
-    :VC "darcs"
-    :LOCATIONS (("latest" . "http://dwim.hu/live/hu.dwim.syntax-sugar/")))
+    :URL "http://dwim.hu/live/hu.dwim.syntax-sugar/")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "hu.dwim.stefil"
-    :VC "darcs"
-    :LOCATIONS (("latest" . "http://dwim.hu/live/hu.dwim.stefil/")))
+    :URL "http://dwim.hu/live/hu.dwim.stefil/")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "hu.dwim.serializer"
-    :VC "darcs"
-    :LOCATIONS (("latest" . "http://dwim.hu/live/hu.dwim.serializer/")))
+    :URL "http://dwim.hu/live/hu.dwim.serializer/")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "hu.dwim.reiterate"
-    :VC "darcs"
-    :LOCATIONS (("latest" . "http://dwim.hu/live/hu.dwim.reiterate/")))
+    :URL "http://dwim.hu/live/hu.dwim.reiterate/")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "hu.dwim.rdbms"
-    :VC "darcs"
-    :LOCATIONS (("latest" . "http://dwim.hu/live/hu.dwim.rdbms/")))
+    :URL "http://dwim.hu/live/hu.dwim.rdbms/")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "hu.dwim.quasi-quote"
-    :VC "darcs"
-    :LOCATIONS (("latest" . "http://dwim.hu/live/hu.dwim.quasi-quote/")))
+    :URL "http://dwim.hu/live/hu.dwim.quasi-quote/")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "hu.dwim.presentation"
-    :VC "darcs"
-    :LOCATIONS (("latest" . "http://dwim.hu/live/hu.dwim.presentation/")))
+    :URL "http://dwim.hu/live/hu.dwim.presentation/")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "hu.dwim.perec"
-    :VC "darcs"
-    :LOCATIONS (("latest" . "http://dwim.hu/live/hu.dwim.perec/")))
+    :URL "http://dwim.hu/live/hu.dwim.perec/")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "hu.dwim.partial-eval"
-    :VC "darcs"
-    :LOCATIONS (("latest" . "http://dwim.hu/live/hu.dwim.partial-eval/")))
+    :URL "http://dwim.hu/live/hu.dwim.partial-eval/")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "hu.dwim.logger"
-    :VC "darcs"
-    :LOCATIONS (("latest" . "http://dwim.hu/live/hu.dwim.logger/")))
+    :URL "http://dwim.hu/live/hu.dwim.logger/")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "hu.dwim.graphviz"
-    :VC "darcs"
-    :LOCATIONS (("latest" . "http://dwim.hu/live/hu.dwim.graphviz/")))
+    :URL "http://dwim.hu/live/hu.dwim.graphviz/")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "hu.dwim.delico"
-    :VC "darcs"
-    :LOCATIONS (("latest" . "http://dwim.hu/live/hu.dwim.delico/")))
+    :URL "http://dwim.hu/live/hu.dwim.delico/")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "hu.dwim.defclass-star"
-    :VC "darcs"
-    :LOCATIONS (("latest" . "http://dwim.hu/live/hu.dwim.defclass-star/")))
+    :URL "http://dwim.hu/live/hu.dwim.defclass-star/")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "hu.dwim.def"
-    :VC "darcs"
-    :LOCATIONS (("latest" . "http://dwim.hu/live/hu.dwim.def/")))
+    :URL "http://dwim.hu/live/hu.dwim.def/")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "hu.dwim.debug"
-    :VC "darcs"
-    :LOCATIONS (("latest" . "http://dwim.hu/live/hu.dwim.debug")))
+    :URL "http://dwim.hu/live/hu.dwim.debug")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "hu.dwim.computed-class"
-    :VC "darcs"
-    :LOCATIONS (("latest" . "http://dwim.hu/live/hu.dwim.computed-class/")))
+    :URL "http://dwim.hu/live/hu.dwim.computed-class/")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "hu.dwim.common"
-    :VC "darcs"
-    :LOCATIONS (("latest" . "http://dwim.hu/live/hu.dwim.common/")))
+    :URL "http://dwim.hu/live/hu.dwim.common/")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "hu.dwim.common-lisp"
-    :VC "darcs"
-    :LOCATIONS (("latest" . "http://dwim.hu/live/hu.dwim.common-lisp/")))
+    :URL "http://dwim.hu/live/hu.dwim.common-lisp/")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "hu.dwim.asdf"
-    :VC "darcs"
-    :LOCATIONS (("latest" . "http://dwim.hu/live/hu.dwim.asdf/")))
+    :URL "http://dwim.hu/live/hu.dwim.asdf/")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "http-parse"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/orthecreedence/http-parse.git")))
+    :URL "https://github.com/orthecreedence/http-parse.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "http-body"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/fukamachi/http-body.git")))
+    :URL "https://github.com/fukamachi/http-body.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "html-template"
-    :VC "http"
-    :LOCATIONS (("latest" . "http://weitz.de/files/html-template.tar.gz")))
+    :URL "http://weitz.de/files/html-template.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "html-sugar"
-    :VC "http-bz2"
-    :LOCATIONS (("latest"
-                 . "http://wcp.sdf-eu.org/software/html-sugar-latest.tbz")))
+    :URL "http://wcp.sdf-eu.org/software/html-sugar-latest.tbz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "html-entities"
-    :VC "svn"
-    :LOCATIONS (("latest" . "http://html-entities.googlecode.com/svn/trunk/")))
+    :URL "http://html-entities.googlecode.com/svn/trunk/")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "html-encode"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://beta.quicklisp.org/orphans/html-encode-1.2.tgz")))
+    :URL "http://beta.quicklisp.org/orphans/html-encode-1.2.tgz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "ht-simple-ajax"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/martin-loetzsch/ht-simple-ajax.git")))
+    :URL "https://github.com/martin-loetzsch/ht-simple-ajax.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "ht-ajax"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/ht-ajax/files/ht-ajax.tar.gz")))
+    :URL "http://common-lisp.net/project/ht-ajax/files/ht-ajax.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "hspell"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/death/hspell.git")))
+    :URL "https://github.com/death/hspell.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "hl7-parser"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/MartinEnders/hl7-parser.git")))
+    :URL "https://github.com/MartinEnders/hl7-parser.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "hl7-client"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/MartinEnders/hl7-client.git")))
+    :URL "https://github.com/MartinEnders/hl7-client.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "hinge"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/sshirokov/hinge.git")))
+    :URL "https://github.com/sshirokov/hinge.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "hh-web"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/hargettp/hh-web.git")))
+    :URL "https://github.com/hargettp/hh-web.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "hh-redblack"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/hargettp/hh-redblack.git")))
+    :URL "https://github.com/hargettp/hh-redblack.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "hh-aws"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/hargettp/hh-aws.git")))
+    :URL "https://github.com/hargettp/hh-aws.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "hermetic"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/eudoxia0/hermetic.git")))
+    :URL "https://github.com/eudoxia0/hermetic.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "hemlock"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/bluelisp/hemlock.git")))
+    :URL "https://github.com/bluelisp/hemlock.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "helambdap"
-    :VC "git"
-    :LOCATIONS (("latest" . "git://git.code.sf.net/p/helambdap/code")))
+    :URL "git://git.code.sf.net/p/helambdap/code")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "hdf5-cffi"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/HDFGroup/hdf5-cffi.git")))
+    :URL "https://github.com/HDFGroup/hdf5-cffi.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "hash-set"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/samebchase/hash-set.git")))
+    :URL "https://github.com/samebchase/hash-set.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "halftone"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Shinmera/halftone.git")))
+    :URL "https://github.com/Shinmera/halftone.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "gzip-stream"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/gzip-stream/files/gzip-stream_latest.tgz")))
+    :URL "http://common-lisp.net/project/gzip-stream/files/gzip-stream_latest.tgz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "gtk-cffi"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Kalimehtar/gtk-cffi.git")))
+    :URL "https://github.com/Kalimehtar/gtk-cffi.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "gtfl"
-    :VC "http"
-    :LOCATIONS (("latest" . "http://martin-loetzsch.de/gtfl/gtfl.tar.gz")))
+    :URL "http://martin-loetzsch.de/gtfl/gtfl.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "gsll"
-    :VC "branched-git"
-    :LOCATIONS (("latest"
-                 . "https://gitlab.common-lisp.net/antik/gsll.git master")))
+    :URL "https://gitlab.common-lisp.net/antik/gsll.git master")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "gsharp"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://gitlab.common-lisp.net/gsharp/gsharp.git")))
+    :URL "https://gitlab.common-lisp.net/gsharp/gsharp.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "group-by"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/AccelerationNet/group-by.git")))
+    :URL "https://github.com/AccelerationNet/group-by.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "green-threads"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/thezerobit/green-threads.git")))
+    :URL "https://github.com/thezerobit/green-threads.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "graylex"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/e-user/graylex.git")))
+    :URL "https://github.com/e-user/graylex.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "graph"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/eschulte/graph.git")))
+    :URL "https://github.com/eschulte/graph.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "gordon"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/sgarciac/gordon.git")))
+    :URL "https://github.com/sgarciac/gordon.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "glyphs"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/ahungry/glyphs.git")))
+    :URL "https://github.com/ahungry/glyphs.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "glu-tessellate"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/orthecreedence/glu-tessellate.git")))
+    :URL "https://github.com/orthecreedence/glu-tessellate.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "glop"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/patzy/glop.git")))
+    :URL "https://github.com/patzy/glop.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "global-vars"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/lmj/global-vars.git")))
+    :URL "https://github.com/lmj/global-vars.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "glkit"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/lispgames/glkit.git")))
+    :URL "https://github.com/lispgames/glkit.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "glaw"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/patzy/glaw.git")))
+    :URL "https://github.com/patzy/glaw.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "glass"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/fjames86/glass.git")))
+    :URL "https://github.com/fjames86/glass.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "gettext"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/copyleft/gettext.git")))
+    :URL "https://github.com/copyleft/gettext.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "getopt"
-    :VC "kmr-git"
-    :LOCATIONS (("latest" . "getopt")))
+    :URL "getopt")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "genhash"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/pnathan/genhash.git")))
+    :URL "https://github.com/pnathan/genhash.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "genhash"
-    :VC "http"
-    :LOCATIONS (("latest" . "http://src.hexapodia.net/genhash.tar.gz")))
+    :URL "http://src.hexapodia.net/genhash.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "geneva"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/inters/geneva.git")))
+    :URL "https://github.com/inters/geneva.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "generic-sequences"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/dsorokin/generic-sequences.git")))
+    :URL "https://github.com/dsorokin/generic-sequences.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "generic-comparability"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/pnathan/generic-comparability.git")))
+    :URL "https://github.com/pnathan/generic-comparability.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "generators"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/AccelerationNet/generators.git")))
+    :URL "https://github.com/AccelerationNet/generators.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "gendl"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://gitlab.common-lisp.net/gendl/gendl.git")))
+    :URL "https://gitlab.common-lisp.net/gendl/gendl.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "gcm"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/death/gcm.git")))
+    :URL "https://github.com/death/gcm.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "gbbopen"
-    :VC "svn"
-    :LOCATIONS (("latest" . "http://gbbopen.org/svn/GBBopen/trunk/")))
+    :URL "http://gbbopen.org/svn/GBBopen/trunk/")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "garbage-pools"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/archimag/garbage-pools.git")))
+    :URL "https://github.com/archimag/garbage-pools.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "funds"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/funds/funds.tar.gz")))
+    :URL "http://common-lisp.net/project/funds/funds.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "function-literal"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/GordianNaught/Function-Literal.git")))
+    :URL "https://github.com/GordianNaught/Function-Literal.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "function-cache"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/AccelerationNet/function-cache.git")))
+    :URL "https://github.com/AccelerationNet/function-cache.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "fucc"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/fucc/files/fucc_0.2.1-alpha-20080624.tar.gz")))
+    :URL "http://common-lisp.net/project/fucc/files/fucc_0.2.1-alpha-20080624.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "fsvd"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/melisgl/fsvd.git")))
+    :URL "https://github.com/melisgl/fsvd.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "fset"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/slburson/fset.git")))
+    :URL "https://github.com/slburson/fset.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "fs-watcher"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Ralt/fs-watcher.git")))
+    :URL "https://github.com/Ralt/fs-watcher.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "frpc"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/fjames86/frpc.git")))
+    :URL "https://github.com/fjames86/frpc.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "fred"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/plkrueger/CommonLispFred.git")))
+    :URL "https://github.com/plkrueger/CommonLispFred.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "formlets"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Inaimathi/formlets.git")))
+    :URL "https://github.com/Inaimathi/formlets.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "form-fiddle"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Shinmera/form-fiddle.git")))
+    :URL "https://github.com/Shinmera/form-fiddle.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "fomus"
-    :VC "svn"
-    :LOCATIONS (("latest"
-                 . "svn://common-lisp.net/project/fomus/svn/fomus/trunk")))
+    :URL "svn://common-lisp.net/project/fomus/svn/fomus/trunk")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "folio2"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/mikelevins/folio2.git")))
+    :URL "https://github.com/mikelevins/folio2.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "folio"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/mikelevins/folio.git")))
+    :URL "https://github.com/mikelevins/folio.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "fnv"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/blindglobe/fnv.git")))
+    :URL "https://github.com/blindglobe/fnv.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "fn"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/cbaggers/fn.git")))
+    :URL "https://github.com/cbaggers/fn.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "fmt"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/mmontone/fmt.git")))
+    :URL "https://github.com/mmontone/fmt.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "floating-point"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/OdonataResearchLLC/floating-point.git")))
+    :URL "https://github.com/OdonataResearchLLC/floating-point.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "flexichain"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/flexichain/download/flexichain_latest.tgz")))
+    :URL "http://common-lisp.net/project/flexichain/download/flexichain_latest.tgz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "flexi-streams"
-    :VC "http"
-    :LOCATIONS (("latest" . "http://weitz.de/files/flexi-streams.tar.gz")))
+    :URL "http://weitz.de/files/flexi-streams.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "fiveam"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/fiveam/files/fiveam-latest.tar.gz")))
+    :URL "http://common-lisp.net/project/fiveam/files/fiveam-latest.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "firephp"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/html/firephp.git")))
+    :URL "https://github.com/html/firephp.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "find-port"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/eudoxia0/find-port.git")))
+    :URL "https://github.com/eudoxia0/find-port.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "filtered-functions"
-    :VC "darcs"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/closer/repos/filtered-functions/")))
+    :URL "http://common-lisp.net/project/closer/repos/filtered-functions/")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "file-types"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/eugeneia/file-types.git")))
+    :URL "https://github.com/eugeneia/file-types.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "fiasco"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/capitaomorte/fiasco.git")))
+    :URL "https://github.com/capitaomorte/fiasco.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "fft"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/nklein/FFT.git")))
+    :URL "https://github.com/nklein/FFT.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "ffa"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/tpapp/ffa.git")))
+    :URL "https://github.com/tpapp/ffa.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "femlisp"
-    :VC "git"
-    :LOCATIONS (("latest" . "git://git.savannah.nongnu.org/femlisp.git")))
+    :URL "git://git.savannah.nongnu.org/femlisp.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "fast-io"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/rpav/fast-io.git")))
+    :URL "https://github.com/rpav/fast-io.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "fast-http"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/fukamachi/fast-http.git")))
+    :URL "https://github.com/fukamachi/fast-http.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "fare-utils"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://gitlab.common-lisp.net/frideau/fare-utils.git")))
+    :URL "https://gitlab.common-lisp.net/frideau/fare-utils.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "fare-quasiquote"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://gitlab.common-lisp.net/frideau/fare-quasiquote.git")))
+    :URL "https://gitlab.common-lisp.net/frideau/fare-quasiquote.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "fare-mop"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://gitlab.common-lisp.net/frideau/fare-mop.git")))
+    :URL "https://gitlab.common-lisp.net/frideau/fare-mop.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "fare-memoization"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://gitlab.common-lisp.net/frideau/fare-memoization.git")))
+    :URL "https://gitlab.common-lisp.net/frideau/fare-memoization.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "fare-csv"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://gitlab.common-lisp.net/frideau/fare-csv.git")))
+    :URL "https://gitlab.common-lisp.net/frideau/fare-csv.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "f2cl"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://gitlab.common-lisp.net/f2cl/f2cl.git")))
+    :URL "https://gitlab.common-lisp.net/f2cl/f2cl.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "f-underscore"
-    :VC "darcs"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/bpm/darcs/f-underscore")))
+    :URL "https://github.com/nallen05/f-underscore.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "external-program"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/sellout/external-program.git")))
+    :URL "https://github.com/sellout/external-program.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "extended-reals"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/tpapp/extended-reals.git")))
+    :URL "https://github.com/tpapp/extended-reals.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "ext-blog"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/kevinlynx/ext-blog.git")))
+    :URL "https://github.com/kevinlynx/ext-blog.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "exscribe"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://gitlab.common-lisp.net/frideau/exscribe.git")))
+    :URL "https://gitlab.common-lisp.net/frideau/exscribe.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "exponential-backoff"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/death/exponential-backoff.git")))
+    :URL "https://github.com/death/exponential-backoff.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "evol"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/e-user/evol.git")))
+    :URL "https://github.com/e-user/evol.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "event-glue"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/orthecreedence/event-glue.git")))
+    :URL "https://github.com/orthecreedence/event-glue.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "event-emitter"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/fukamachi/event-emitter.git")))
+    :URL "https://github.com/fukamachi/event-emitter.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "esrap"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/scymtym/esrap.git")))
+    :URL "https://github.com/scymtym/esrap.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "esrap-peg"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/fb08af68/esrap-peg.git")))
+    :URL "https://github.com/fb08af68/esrap-peg.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "esrap-liquid"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/mabragor/esrap-liquid.git")))
+    :URL "https://github.com/mabragor/esrap-liquid.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "escalator"
-    :VC "mercurial"
-    :LOCATIONS (("latest"
-                 . "https://bitbucket.org/elliottslaughter/escalator")))
+    :URL "https://bitbucket.org/elliottslaughter/escalator")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "erudite"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/mmontone/erudite.git")))
+    :URL "https://github.com/mmontone/erudite.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "ernestine"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/nlamirault/ernestine.git")))
+    :URL "https://github.com/nlamirault/ernestine.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "equals"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/csziacobus/equals.git")))
+    :URL "https://github.com/csziacobus/equals.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "epigraph"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/slyrus/epigraph.git")))
+    :URL "https://github.com/slyrus/epigraph.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "eos"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/adlai/Eos.git")))
+    :URL "https://github.com/adlai/Eos.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "envy"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/fukamachi/envy.git")))
+    :URL "https://github.com/fukamachi/envy.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "enhanced-multiple-value-bind"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://tarballs.hexstreamsoft.com/libraries/latest/enhanced-multiple-value-bind_latest.tar.gz")))
+    :URL "http://tarballs.hexstreamsoft.com/libraries/latest/enhanced-multiple-value-bind_latest.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "enhanced-eval-when"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://tarballs.hexstreamsoft.com/libraries/latest/enhanced-eval-when_latest.tar.gz")))
+    :URL "http://tarballs.hexstreamsoft.com/libraries/latest/enhanced-eval-when_latest.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "elf"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/eschulte/elf.git")))
+    :URL "https://github.com/eschulte/elf.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "elephant"
-    :VC "darcs"
-    :LOCATIONS (("latest"
-                 . "http://www.common-lisp.net/project/elephant/darcs/elephant-1.0")))
+    :URL "http://www.common-lisp.net/project/elephant/darcs/elephant-1.0")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "elb-log"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Rudolph-Miller/elb-log.git")))
+    :URL "https://github.com/Rudolph-Miller/elb-log.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "eco"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/eudoxia0/eco.git")))
+    :URL "https://github.com/eudoxia0/eco.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "ec2"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/nikodemus/ec2.git")))
+    :URL "https://github.com/nikodemus/ec2.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "eazy-project"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/guicho271828/eazy-project.git")))
+    :URL "https://github.com/guicho271828/eazy-project.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "eazy-process"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/guicho271828/eazy-process.git")))
+    :URL "https://github.com/guicho271828/eazy-process.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "eazy-gnuplot"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/guicho271828/eazy-gnuplot.git")))
+    :URL "https://github.com/guicho271828/eazy-gnuplot.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "eager-future2"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/eager-future/release/eager-future2-0.2.tgz")))
+    :URL "http://common-lisp.net/project/eager-future/release/eager-future2-0.2.tgz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "eager-future"
-    :VC "darcs"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/eager-future/repository/eager-future/")))
+    :URL "http://common-lisp.net/project/eager-future/repository/eager-future/")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "dynamic-mixins"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/rpav/dynamic-mixins.git")))
+    :URL "https://github.com/rpav/dynamic-mixins.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "dynamic-collect"
-    :VC "mercurial"
-    :LOCATIONS (("latest"
-                 . "https://bitbucket.org/tarballs_are_good/dynamic-collect")))
+    :URL "https://bitbucket.org/tarballs_are_good/dynamic-collect")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "dynamic-classes"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/gwkkwg/dynamic-classes.git")))
+    :URL "https://github.com/gwkkwg/dynamic-classes.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "dyna"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Rudolph-Miller/dyna.git")))
+    :URL "https://github.com/Rudolph-Miller/dyna.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "dweet"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/death/dweet.git")))
+    :URL "https://github.com/death/dweet.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "duologue"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/mmontone/duologue.git")))
+    :URL "https://github.com/mmontone/duologue.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "dstm-collections"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/danlentz/dstm-collections.git")))
+    :URL "https://github.com/danlentz/dstm-collections.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "dso-util"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://download.fugue88.ws/util/dso-util-0.1.2.tar.gz")))
+    :URL "http://download.fugue88.ws/util/dso-util-0.1.2.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "dso-lex"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://download.fugue88.ws/lex/dso-lex-0.3.2.tar.gz")))
+    :URL "http://download.fugue88.ws/lex/dso-lex-0.3.2.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "draw-cons-tree"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/cbaggers/draw-cons-tree.git")))
+    :URL "https://github.com/cbaggers/draw-cons-tree.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "drakma"
-    :VC "http"
-    :LOCATIONS (("latest" . "https://github.com/edicl/drakma/archive/master.tar.gz")))
+    :URL "https://github.com/edicl/drakma/archive/master.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "drakma-async"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/orthecreedence/drakma-async.git")))
+    :URL "https://github.com/orthecreedence/drakma-async.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "doplus"
-    :VC "mercurial"
-    :LOCATIONS (("latest" . "https://code.google.com/p/doplus/")))
+    :URL "https://code.google.com/p/doplus/")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "donuts"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/tkych/donuts.git")))
+    :URL "https://github.com/tkych/donuts.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "documentation-template"
-    :VC "http"
-    :LOCATIONS (("latest" . "http://weitz.de/files/documentation-template.tar.gz")))
+    :URL "http://weitz.de/files/documentation-template.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "docparser"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/eudoxia0/docparser.git")))
+    :URL "https://github.com/eudoxia0/docparser.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "docbrowser"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/lokedhs/docbrowser.git")))
+    :URL "https://github.com/lokedhs/docbrowser.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "do-urlencode"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/drdo/do-urlencode.git")))
+    :URL "https://github.com/drdo/do-urlencode.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "dlist"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/krzysz00/dlist.git")))
+    :URL "https://github.com/krzysz00/dlist.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "djula"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/mmontone/djula.git")))
+    :URL "https://github.com/mmontone/djula.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "dissect"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Shinmera/dissect.git")))
+    :URL "https://github.com/Shinmera/dissect.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "diff"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/froydnj/diff.git")))
+    :URL "https://github.com/froydnj/diff.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "dexador"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/fukamachi/dexador.git")))
+    :URL "https://github.com/fukamachi/dexador.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "descriptions"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/mmontone/descriptions.git")))
+    :URL "https://github.com/mmontone/descriptions.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "deoxybyte-utilities"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/keithj/deoxybyte-utilities.git")))
+    :URL "https://github.com/keithj/deoxybyte-utilities.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "deoxybyte-unix"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/keithj/deoxybyte-unix.git")))
+    :URL "https://github.com/keithj/deoxybyte-unix.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "deoxybyte-systems"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/keithj/deoxybyte-systems.git")))
+    :URL "https://github.com/keithj/deoxybyte-systems.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "deoxybyte-io"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/keithj/deoxybyte-io.git")))
+    :URL "https://github.com/keithj/deoxybyte-io.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "deoxybyte-gzip"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/keithj/deoxybyte-gzip.git")))
+    :URL "https://github.com/keithj/deoxybyte-gzip.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "delta-debug"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/eschulte/delta-debug.git")))
+    :URL "https://github.com/eschulte/delta-debug.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "delorean"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/cddr/delorean.git")))
+    :URL "https://github.com/cddr/delorean.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "defvariant"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/fredokun/defvariant.git")))
+    :URL "https://github.com/fredokun/defvariant.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "defsystem-compatibility"
-    :VC "darcs"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/cl-containers/defsystem-compatibility/")))
+    :URL "http://common-lisp.net/project/cl-containers/defsystem-compatibility/")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "defstar"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://bitbucket.org/eeeickythump/defstar.git")))
+    :URL "https://bitbucket.org/eeeickythump/defstar.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "defrec"
-    :VC "mercurial"
-    :LOCATIONS (("latest" . "https://bitbucket.org/tarballs_are_good/defrec")))
+    :URL "https://bitbucket.org/tarballs_are_good/defrec")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "defpackage-plus"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/rpav/defpackage-plus.git")))
+    :URL "https://github.com/rpav/defpackage-plus.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "defmemo"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/orivej/defmemo.git")))
+    :URL "https://github.com/orivej/defmemo.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "defmacro-enhance"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/mabragor/defmacro-enhance.git")))
+    :URL "https://github.com/mabragor/defmacro-enhance.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "deflate"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/pmai/Deflate.git")))
+    :URL "https://github.com/pmai/Deflate.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "define-json-expander"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/ejbs/define-json-expander.git")))
+    :URL "https://github.com/ejbs/define-json-expander.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "deferred"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Shinmera/deferred.git")))
+    :URL "https://github.com/Shinmera/deferred.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "defenum"
-    :VC "git"
-    :LOCATIONS (("latest" . "http://git.code.sf.net/p/defenum/code")))
+    :URL "http://git.code.sf.net/p/defenum/code")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "defclass-std"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/EuAndreh/defclass-std.git")))
+    :URL "https://github.com/EuAndreh/defclass-std.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "declt"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "https://www.lrde.epita.fr/~didier/software/lisp/declt/latest.tar.gz")))
+    :URL "https://www.lrde.epita.fr/~didier/software/lisp/declt/latest.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "de.setf.wilbur"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/lisp/de.setf.wilbur.git")))
+    :URL "https://github.com/lisp/de.setf.wilbur.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "dbus"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/death/dbus.git")))
+    :URL "https://github.com/death/dbus.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "date-calc"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/cl-date-calc/date-calc-0.3.tar.gz")))
+    :URL "http://common-lisp.net/project/cl-date-calc/date-calc-0.3.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "datafly"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/fukamachi/datafly.git")))
+    :URL "https://github.com/fukamachi/datafly.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "data-table"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/AccelerationNet/data-table.git")))
+    :URL "https://github.com/AccelerationNet/data-table.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "data-sift"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/archimag/data-sift.git")))
+    :URL "https://github.com/archimag/data-sift.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "dartsclsequencemetrics"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/deterministic-arts/DartsCLSequenceMetrics.git")))
+    :URL "https://github.com/deterministic-arts/DartsCLSequenceMetrics.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "dartsclmessagepack"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/deterministic-arts/DartsCLMessagePack.git")))
+    :URL "https://github.com/deterministic-arts/DartsCLMessagePack.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "dartsclhashtree"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/deterministic-arts/DartsCLHashTree.git")))
+    :URL "https://github.com/deterministic-arts/DartsCLHashTree.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "daemon"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/snmsts/daemon.git")))
+    :URL "https://github.com/snmsts/daemon.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cxml"
-    :VC "git"
-    :LOCATIONS (("latest" . "git://repo.or.cz/cxml.git")))
+    :URL "git://repo.or.cz/cxml.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cxml-stp"
-    :VC "git"
-    :LOCATIONS (("latest" . "http://www.lichteblau.com/git/cxml-stp.git")))
+    :URL "http://www.lichteblau.com/git/cxml-stp.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cxml-rpc"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/antifuchs/cxml-rpc.git")))
+    :URL "https://github.com/antifuchs/cxml-rpc.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cxml-rng"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://www.lichteblau.com/cxml-rng/download/cxml-rng.tar.gz")))
+    :URL "http://www.lichteblau.com/cxml-rng/download/cxml-rng.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "curve"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/elbeno/curve.git")))
+    :URL "https://github.com/elbeno/curve.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "curry-compose-reader-macros"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/eschulte/curry-compose-reader-macros.git")))
+    :URL "https://github.com/eschulte/curry-compose-reader-macros.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "curly"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/mpasternacki/curly.git")))
+    :URL "https://github.com/mpasternacki/curly.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "csv-parser"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/sharplispers/csv-parser.git")))
+    :URL "https://github.com/sharplispers/csv-parser.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "css-selectors"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/AccelerationNet/css-selectors.git")))
+    :URL "https://github.com/AccelerationNet/css-selectors.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "css-lite"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/paddymul/css-lite.git")))
+    :URL "https://github.com/paddymul/css-lite.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "crypto-shortcuts"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/Shinmera/crypto-shortcuts.git")))
+    :URL "https://github.com/Shinmera/crypto-shortcuts.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "croatoan"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/McParen/croatoan.git")))
+    :URL "https://github.com/McParen/croatoan.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "crane"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/eudoxia0/crane.git")))
+    :URL "https://github.com/eudoxia0/crane.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cqlcl"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/AeroNotix/cqlcl.git")))
+    :URL "https://github.com/AeroNotix/cqlcl.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "corona"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/eudoxia0/corona.git")))
+    :URL "https://github.com/eudoxia0/corona.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "contextl"
-    :VC "git"
-    :LOCATIONS (("latest" . "git://git.code.sf.net/p/closer/contextl")))
+    :URL "git://git.code.sf.net/p/closer/contextl")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "consix"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/death/consix.git")))
+    :URL "https://github.com/death/consix.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "conium"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/bluelisp/conium.git")))
+    :URL "https://github.com/bluelisp/conium.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "conduit-packages"
-    :VC "single-file"
-    :LOCATIONS (("latest"
-                 . "http://tfeb.org/programs/lisp/conduit-packages.lisp")))
+    :URL "http://tfeb.org/programs/lisp/conduit-packages.lisp")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "conduit-packages"
-    :VC "single-file"
-    :LOCATIONS (("latest"
-                 . "http://beta.quicklisp.org/orphans/tfeb/conduit-packages.lisp")))
+    :URL "http://beta.quicklisp.org/orphans/tfeb/conduit-packages.lisp")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "computable-reals"
-    :VC "mercurial"
-    :LOCATIONS (("latest"
-                 . "https://bitbucket.org/tarballs_are_good/computable-reals")))
+    :URL "https://bitbucket.org/tarballs_are_good/computable-reals")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "commonqt"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/commonqt/commonqt.git")))
+    :URL "https://github.com/commonqt/commonqt.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "common-lisp-stat"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/blindglobe/common-lisp-stat.git")))
+    :URL "https://github.com/blindglobe/common-lisp-stat.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "common-lisp-actors"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/naveensundarg/Common-Lisp-Actors.git")))
+    :URL "https://github.com/naveensundarg/Common-Lisp-Actors.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "common-html"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/CommonDoc/common-html.git")))
+    :URL "https://github.com/CommonDoc/common-html.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "common-doc"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/CommonDoc/common-doc.git")))
+    :URL "https://github.com/CommonDoc/common-doc.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "common-doc-plump"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/CommonDoc/common-doc-plump.git")))
+    :URL "https://github.com/CommonDoc/common-doc-plump.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "command-line-arguments"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://gitlab.common-lisp.net/qitab/command-line-arguments.git")))
+    :URL "https://gitlab.common-lisp.net/qitab/command-line-arguments.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "com.informatimago"
-    :VC "tagged-git"
-    :LOCATIONS (("latest"
-                 . "https://gitlab.com/com-informatimago/com-informatimago.git quicklisp")))
+    :URL "https://gitlab.com/com-informatimago/com-informatimago.git quicklisp")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "com.google.base"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/brown/base.git")))
+    :URL "https://github.com/brown/base.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "com.clearly-useful.protocols"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/jaeschliman/com.clearly-useful.protocols.git")))
+    :URL "https://github.com/jaeschliman/com.clearly-useful.protocols.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "com.clearly-useful.iterator-protocol"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/jaeschliman/com.clearly-useful.iterator-protocol.git")))
+    :URL "https://github.com/jaeschliman/com.clearly-useful.iterator-protocol.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "com.clearly-useful.iterate-plus"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/jaeschliman/com.clearly-useful.iterate-plus.git")))
+    :URL "https://github.com/jaeschliman/com.clearly-useful.iterate-plus.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "com.clearly-useful.generic-collection-interface"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/jaeschliman/com.clearly-useful.generic-collection-interface.git")))
+    :URL "https://github.com/jaeschliman/com.clearly-useful.generic-collection-interface.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "colorize"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/redline6561/colorize.git")))
+    :URL "https://github.com/redline6561/colorize.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "colleen"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Shinmera/colleen.git")))
+    :URL "https://github.com/Shinmera/colleen.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "collectors"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/AccelerationNet/collectors.git")))
+    :URL "https://github.com/AccelerationNet/collectors.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "coleslaw"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/redline6561/coleslaw.git")))
+    :URL "https://github.com/redline6561/coleslaw.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "codata-recommended-values"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/ralph-schleicher/codata-recommended-values.git")))
+    :URL "https://github.com/ralph-schleicher/codata-recommended-values.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cobstor"
-    :VC "http-bz2"
-    :LOCATIONS (("latest"
-                 . "http://wcp.sdf-eu.org/software/cobstor-latest.tbz")))
+    :URL "http://wcp.sdf-eu.org/software/cobstor-latest.tbz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "clx"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/sharplispers/clx.git")))
+    :URL "https://github.com/sharplispers/clx.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "clx-xkeyboard"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/filonenko-mikhail/clx-xkeyboard.git")))
+    :URL "https://github.com/filonenko-mikhail/clx-xkeyboard.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "clx-xembed"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/laynor/clx-xembed.git")))
+    :URL "https://github.com/laynor/clx-xembed.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "clx-truetype"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/filonenko-mikhail/clx-truetype.git")))
+    :URL "https://github.com/filonenko-mikhail/clx-truetype.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "clx-cursor"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/filonenko-mikhail/clx-cursor.git")))
+    :URL "https://github.com/filonenko-mikhail/clx-cursor.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "clws"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/3b/clws.git")))
+    :URL "https://github.com/3b/clws.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "clweb"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/plotnick/clweb.git")))
+    :URL "https://github.com/plotnick/clweb.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "clunit"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/tgutu/clunit.git")))
+    :URL "https://github.com/tgutu/clunit.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "clss"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Shinmera/clss.git")))
+    :URL "https://github.com/Shinmera/clss.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "clsql"
-    :VC "kmr-git"
-    :LOCATIONS (("latest" . "clsql")))
+    :URL "clsql")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "clsql-orm"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/AccelerationNet/clsql-orm.git")))
+    :URL "https://github.com/AccelerationNet/clsql-orm.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "clsql-helper"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/AccelerationNet/clsql-helper.git")))
+    :URL "https://github.com/AccelerationNet/clsql-helper.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "clsql-fluid"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/html/clsql-fluid.git")))
+    :URL "https://github.com/html/clsql-fluid.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "clpmr"
-    :VC "http-bz2"
-    :LOCATIONS (("latest"
-                 . "http://wcp.sdf-eu.org/software/clpmr-latest.tbz")))
+    :URL "http://wcp.sdf-eu.org/software/clpmr-latest.tbz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "clouchdb"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/clouchdb/clouchdb-latest.tar.gz")))
+    :URL "http://common-lisp.net/project/clouchdb/clouchdb-latest.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "clot"
-    :VC "http-bz2"
-    :LOCATIONS (("latest"
-                 . "http://wcp.sdf-eu.org/software/clot/clot-latest.tbz")))
+    :URL "http://wcp.sdf-eu.org/software/clot/clot-latest.tbz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "closure-html"
-    :VC "git"
-    :LOCATIONS (("latest" . "git://repo.or.cz/closure-html.git")))
+    :URL "git://repo.or.cz/closure-html.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "closure-common"
-    :VC "git"
-    :LOCATIONS (("latest" . "git://repo.or.cz/closure-common.git")))
+    :URL "git://repo.or.cz/closure-common.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "closer-mop"
-    :VC "git"
-    :LOCATIONS (("latest" . "git://git.code.sf.net/p/closer/closer-mop")))
+    :URL "https://github.com/pcostanza/closer-mop.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "clos-fixtures"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/eudoxia0/clos-fixtures.git")))
+    :URL "https://github.com/eudoxia0/clos-fixtures.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "clos-diff"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/krzysz00/clos-diff.git")))
+    :URL "https://github.com/krzysz00/clos-diff.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "clonsigna"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://gitlab.common-lisp.net/clonsigna/clonsigna.git")))
+    :URL "https://gitlab.common-lisp.net/clonsigna/clonsigna.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "clon"
-    :VC "git"
-    :LOCATIONS (("latest" . "http://quotenil.com/git/clon.git")))
+    :URL "http://quotenil.com/git/clon.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "clods-export"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/jlahd/clods-export.git")))
+    :URL "https://github.com/jlahd/clods-export.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "clod"
-    :VC "mercurial"
-    :LOCATIONS (("latest" . "https://bitbucket.org/eeeickythump/clod")))
+    :URL "https://bitbucket.org/eeeickythump/clod")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "clobber"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/robert-strandh/Clobber.git")))
+    :URL "https://github.com/robert-strandh/Clobber.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "clnuplot"
-    :VC "darcs"
-    :LOCATIONS (("latest" . "http://common-lisp.net/project/clnuplot")))
+    :URL "http://common-lisp.net/project/clnuplot")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "clml"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/mmaul/clml.git")))
+    :URL "https://github.com/mmaul/clml.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "clite"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/lispy-stuff/clite.git")))
+    :URL "https://github.com/lispy-stuff/clite.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "clipper"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Rudolph-Miller/clipper.git")))
+    :URL "https://github.com/Rudolph-Miller/clipper.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "clip"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Shinmera/clip.git")))
+    :URL "https://github.com/Shinmera/clip.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "clinch"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/BradWBeer/CLinch.git")))
+    :URL "https://github.com/BradWBeer/CLinch.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "climon"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/nlamirault/climon.git")))
+    :URL "https://github.com/nlamirault/climon.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "climc"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/nlamirault/climc.git")))
+    :URL "https://github.com/nlamirault/climc.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "climacs"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://gitlab.common-lisp.net/climacs/climacs.git")))
+    :URL "https://gitlab.common-lisp.net/climacs/climacs.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "clim-widgets"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/jschatzer/clim-widgets.git")))
+    :URL "https://github.com/jschatzer/clim-widgets.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "clim-pkg-doc"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/jschatzer/clim-pkg-doc.git")))
+    :URL "https://github.com/jschatzer/clim-pkg-doc.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "clickr"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/schani/clickr.git")))
+    :URL "https://github.com/schani/clickr.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "clhs"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://tarballs.hexstreamsoft.com/libraries/latest/clhs_latest.tar.gz")))
+    :URL "http://tarballs.hexstreamsoft.com/libraries/latest/clhs_latest.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "clfswm"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://gitlab.common-lisp.net/clfswm/clfswm.git")))
+    :URL "https://gitlab.common-lisp.net/clfswm/clfswm.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cletris"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/nlamirault/cletris.git")))
+    :URL "https://github.com/nlamirault/cletris.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "clesh"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Neronus/clesh.git")))
+    :URL "https://github.com/Neronus/clesh.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cleric"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/flambard/CLERIC.git")))
+    :URL "https://github.com/flambard/CLERIC.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "clem"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/slyrus/clem.git")))
+    :URL "https://github.com/slyrus/clem.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "clazy"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://gitlab.common-lisp.net/clazy/clazy.git")))
+    :URL "https://gitlab.common-lisp.net/clazy/clazy.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "clawk"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/sharplispers/clawk.git")))
+    :URL "https://github.com/sharplispers/clawk.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "clavier"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/mmontone/clavier.git")))
+    :URL "https://github.com/mmontone/clavier.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "clavatar"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/pinterface/clavatar.git")))
+    :URL "https://github.com/pinterface/clavatar.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "classimp"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/3b/classimp.git")))
+    :URL "https://github.com/3b/classimp.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "clack"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/fukamachi/clack.git")))
+    :URL "https://github.com/fukamachi/clack.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "clack-errors"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/eudoxia0/clack-errors.git")))
+    :URL "https://github.com/eudoxia0/clack-errors.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "clache"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/html/clache.git")))
+    :URL "https://github.com/html/clache.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl4store"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/mmontone/cl4store.git")))
+    :URL "https://github.com/mmontone/cl4store.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-zmq"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/freiksenet/cl-zmq.git")))
+    :URL "https://github.com/freiksenet/cl-zmq.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-yaml"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/eudoxia0/cl-yaml.git")))
+    :URL "https://github.com/eudoxia0/cl-yaml.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-yahoo-finance"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/pnathan/cl-yahoo-finance.git")))
+    :URL "https://github.com/pnathan/cl-yahoo-finance.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-yaclyaml"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/mabragor/cl-yaclyaml.git")))
+    :URL "https://github.com/mabragor/cl-yaclyaml.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-yacc"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/jech/cl-yacc.git")))
+    :URL "https://github.com/jech/cl-yacc.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-xul"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/mmontone/cl-xul.git")))
+    :URL "https://github.com/mmontone/cl-xul.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-xspf"
-    :VC "svn"
-    :LOCATIONS (("latest" . "http://cl-xspf.googlecode.com/svn/trunk/")))
+    :URL "http://cl-xspf.googlecode.com/svn/trunk/")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-xmpp"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/cl-xmpp/cl-xmpp_latest.tar.gz")))
+    :URL "http://common-lisp.net/project/cl-xmpp/cl-xmpp_latest.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-xmlspam"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/cl-xmlspam/cl-xmlspam.tgz")))
+    :URL "http://common-lisp.net/project/cl-xmlspam/cl-xmlspam.tgz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-xkeysym"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/stumpwm/cl-xkeysym.git")))
+    :URL "https://github.com/stumpwm/cl-xkeysym.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-wkb"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://surejourney.com/software/cl-wkb/cl-wkb-0.1.tar.gz")))
+    :URL "http://surejourney.com/software/cl-wkb/cl-wkb-0.1.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-win32ole"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/quek/cl-win32ole.git")))
+    :URL "https://github.com/quek/cl-win32ole.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-who"
-    :VC "http"
-    :LOCATIONS (("latest" . "http://weitz.de/files/cl-who.tar.gz")))
+    :URL "http://weitz.de/files/cl-who.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-webkit"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/joachifm/cl-webkit.git")))
+    :URL "https://github.com/joachifm/cl-webkit.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-webdav"
-    :VC "http"
-    :LOCATIONS (("latest" . "http://weitz.de/files/cl-webdav.tar.gz")))
+    :URL "http://weitz.de/files/cl-webdav.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-web-crawler"
-    :VC "svn"
-    :LOCATIONS (("latest"
-                 . "http://cl-web-crawler.googlecode.com/svn/trunk/")))
+    :URL "http://cl-web-crawler.googlecode.com/svn/trunk/")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-wbxml"
-    :VC "http"
-    :LOCATIONS (("latest" . "http://weitz.de/files/cl-wbxml.tar.gz")))
+    :URL "http://weitz.de/files/cl-wbxml.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-wav"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/RobBlackwell/cl-wav.git")))
+    :URL "https://github.com/RobBlackwell/cl-wav.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-wal"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://iweb.dl.sourceforge.net/project/cl-wal/cl-wal-0.4.tgz")))
+    :URL "http://iweb.dl.sourceforge.net/project/cl-wal/cl-wal-0.4.tgz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-voxelize"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/takagi/cl-voxelize.git")))
+    :URL "https://github.com/takagi/cl-voxelize.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-virtualbox"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/eudoxia0/cl-virtualbox.git")))
+    :URL "https://github.com/eudoxia0/cl-virtualbox.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-vectors"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/fjolliton/cl-vectors.git")))
+    :URL "https://github.com/fjolliton/cl-vectors.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-variates"
-    :VC "darcs"
-    :LOCATIONS (("latest" . "http://common-lisp.net/project/cl-variates")))
+    :URL "http://common-lisp.net/project/cl-variates")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-v4l2"
-    :VC "git"
-    :LOCATIONS (("latest" . "git://repo.or.cz/cl-v4l2.git")))
+    :URL "git://repo.or.cz/cl-v4l2.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-utilities"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/cl-utilities/cl-utilities-latest.tar.gz")))
+    :URL "http://common-lisp.net/project/cl-utilities/cl-utilities-latest.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-unification"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://gitlab.common-lisp.net/cl-unification/cl-unification.git")))
+    :URL "https://gitlab.common-lisp.net/cl-unification/cl-unification.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-unicode"
-    :VC "http"
-    :LOCATIONS (("latest" . "http://weitz.de/files/cl-unicode.tar.gz")))
+    :URL "http://weitz.de/files/cl-unicode.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-uglify-js"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/mishoo/cl-uglify-js.git")))
+    :URL "https://github.com/mishoo/cl-uglify-js.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-typesetting"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/mbattyani/cl-typesetting.git")))
+    :URL "https://github.com/mbattyani/cl-typesetting.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-twitter"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/fons/cl-twitter.git")))
+    :URL "https://github.com/fons/cl-twitter.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-tuples"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/johnfredcee/cl-tuples.git")))
+    :URL "https://github.com/johnfredcee/cl-tuples.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-tulip-graph"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/varjagg/cl-tulip-graph.git")))
+    :URL "https://github.com/varjagg/cl-tulip-graph.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-toolbox"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://iweb.dl.sourceforge.net/project/cl-toolbox/cl-toolbox-0.4.tgz")))
+    :URL "http://iweb.dl.sourceforge.net/project/cl-toolbox/cl-toolbox-0.4.tgz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-tokyo-cabinet"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/keithj/cl-tokyo-cabinet.git")))
+    :URL "https://github.com/keithj/cl-tokyo-cabinet.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-tld"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/1u4nx/cl-tld.git")))
+    :URL "https://github.com/1u4nx/cl-tld.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-tk"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/marijnh/cl-tk.git")))
+    :URL "https://github.com/marijnh/cl-tk.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-tidy"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/gonzojive/cl-tidy")))
+    :URL "https://github.com/gonzojive/cl-tidy")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-tga"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/fisxoj/cl-tga.git")))
+    :URL "https://github.com/fisxoj/cl-tga.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-template"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/alpha123/cl-template.git")))
+    :URL "https://github.com/alpha123/cl-template.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-tcod"
-    :VC "mercurial"
-    :LOCATIONS (("latest" . "https://bitbucket.org/eeeickythump/cl-tcod")))
+    :URL "https://bitbucket.org/eeeickythump/cl-tcod")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-tap-producer"
-    :VC "git"
-    :LOCATIONS (("latest" . "git://git.code.sf.net/p/cl-tap-producer/code")))
+    :URL "git://git.code.sf.net/p/cl-tap-producer/code")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-table"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Kalimehtar/cl-table.git")))
+    :URL "https://github.com/Kalimehtar/cl-table.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-syslog"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/mmaul/cl-syslog.git")))
+    :URL "https://github.com/mmaul/cl-syslog.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-syntax"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/m2ym/cl-syntax")))
+    :URL "https://github.com/m2ym/cl-syntax")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-swap-file"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://iweb.dl.sourceforge.net/project/cl-swap-file/cl-swap-file-0.5.tgz")))
+    :URL "http://iweb.dl.sourceforge.net/project/cl-swap-file/cl-swap-file-0.5.tgz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-svm"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/gonzojive/cl-svm")))
+    :URL "https://github.com/gonzojive/cl-svm")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-svg"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/wmannis/cl-svg")))
+    :URL "https://github.com/wmannis/cl-svg")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-string-match"
-    :VC "mercurial"
-    :LOCATIONS (("latest" . "https://bitbucket.org/vityok/cl-string-match")))
+    :URL "https://bitbucket.org/vityok/cl-string-match")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-string-complete"
-    :VC "mercurial"
-    :LOCATIONS (("latest"
-                 . "https://bitbucket.org/tarballs_are_good/cl-string-complete")))
+    :URL "https://bitbucket.org/tarballs_are_good/cl-string-complete")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-strftime"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/ruricolist/cl-strftime.git")))
+    :URL "https://github.com/ruricolist/cl-strftime.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-store"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/skypher/cl-store.git")))
+    :URL "https://github.com/skypher/cl-store.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-stopwatch"
-    :VC "mercurial"
-    :LOCATIONS (("latest"
-                 . "https://bitbucket.org/tarballs_are_good/cl-stopwatch")))
+    :URL "https://bitbucket.org/tarballs_are_good/cl-stopwatch")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-stomp"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://gitlab.common-lisp.net/cl-stomp/cl-stomp.git")))
+    :URL "https://gitlab.common-lisp.net/cl-stomp/cl-stomp.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-stm"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/cl-stm/latest.tar.gz")))
+    :URL "http://common-lisp.net/project/cl-stm/latest.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-stdutils"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/eslick/cl-stdutils.git")))
+    :URL "https://github.com/eslick/cl-stdutils.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-sqlite"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/dmitryvk/cl-sqlite.git")))
+    :URL "https://github.com/dmitryvk/cl-sqlite.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-splicing-macro"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/mabragor/cl-splicing-macro.git")))
+    :URL "https://github.com/mabragor/cl-splicing-macro.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-sphinx"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/archimag/cl-sphinx.git")))
+    :URL "https://github.com/archimag/cl-sphinx.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-speedy-queue"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/zkat/cl-speedy-queue.git")))
+    :URL "https://github.com/zkat/cl-speedy-queue.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-spark"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/tkych/cl-spark.git")))
+    :URL "https://github.com/tkych/cl-spark.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-sophia"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/multimethod/cl-sophia.git")))
+    :URL "https://github.com/multimethod/cl-sophia.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-smtp"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://gitlab.common-lisp.net/cl-smtp/cl-smtp.git")))
+    :URL "https://gitlab.common-lisp.net/cl-smtp/cl-smtp.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-slug"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/EuAndreh/cl-slug.git")))
+    :URL "https://github.com/EuAndreh/cl-slug.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-slp"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/fjames86/cl-slp.git")))
+    :URL "https://github.com/fjames86/cl-slp.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-slice"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/tpapp/cl-slice.git")))
+    :URL "https://github.com/tpapp/cl-slice.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-sl4a"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/jkordani/cl-sl4a.git")))
+    :URL "https://github.com/jkordani/cl-sl4a.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-skip-list"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/kraison/cl-skip-list.git")))
+    :URL "https://github.com/kraison/cl-skip-list.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-singleton-mixin"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/hipeta/cl-singleton-mixin.git")))
+    :URL "https://github.com/hipeta/cl-singleton-mixin.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-simple-table"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/ebobby/cl-simple-table.git")))
+    :URL "https://github.com/ebobby/cl-simple-table.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-simple-concurrent-jobs"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/JordanPowell/cl-simple-concurrent-jobs.git")))
+    :URL "https://github.com/JordanPowell/cl-simple-concurrent-jobs.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-shellwords"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/jorams/cl-shellwords.git")))
+    :URL "https://github.com/jorams/cl-shellwords.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-server-manager"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/pw4ever/cl-server-manager.git")))
+    :URL "https://github.com/pw4ever/cl-server-manager.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-sentiment"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/RobBlackwell/cl-sentiment.git")))
+    :URL "https://github.com/RobBlackwell/cl-sentiment.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-sendmail"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/u-u-h/cl-sendmail.git")))
+    :URL "https://github.com/u-u-h/cl-sendmail.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-selenium"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/html/cl-selenium.git")))
+    :URL "https://github.com/html/cl-selenium.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-secure-read"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/mabragor/cl-secure-read.git")))
+    :URL "https://github.com/mabragor/cl-secure-read.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-sdl2"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/lispgames/cl-sdl2.git")))
+    :URL "https://github.com/lispgames/cl-sdl2.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-scrobbler"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/redline6561/cl-scrobbler.git")))
+    :URL "https://github.com/redline6561/cl-scrobbler.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-scripting"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/fare/cl-scripting.git")))
+    :URL "https://github.com/fare/cl-scripting.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-scribd"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/jsmpereira/cl-scribd.git")))
+    :URL "https://github.com/jsmpereira/cl-scribd.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-sasl"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://xn--9dbdkw.se/cl-sasl/cl-sasl_0.3.1.tar.gz")))
+    :URL "http://xn--9dbdkw.se/cl-sasl/cl-sasl_0.3.1.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-sanitize"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/archimag/cl-sanitize.git")))
+    :URL "https://github.com/archimag/cl-sanitize.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-sane"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://repo.or.cz/cl-sane.git")))
+    :URL "https://repo.or.cz/cl-sane.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-sam"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/keithj/cl-sam.git")))
+    :URL "https://github.com/keithj/cl-sam.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-sails"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/gonzojive/cl-sails")))
+    :URL "https://github.com/gonzojive/cl-sails")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-s3"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/svenvc/cl-s3.git")))
+    :URL "https://github.com/svenvc/cl-s3.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-rsvg2"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/roerd/cl-rsvg2.git")))
+    :URL "https://github.com/roerd/cl-rsvg2.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-rss"
-    :VC "kmr-git"
-    :LOCATIONS (("latest" . "cl-rss")))
+    :URL "cl-rss")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-rrt"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/guicho271828/cl-rrt.git")))
+    :URL "https://github.com/guicho271828/cl-rrt.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-rrd"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/hbock/cl-rrd.git")))
+    :URL "https://github.com/hbock/cl-rrd.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-routes"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/archimag/cl-routes.git")))
+    :URL "https://github.com/archimag/cl-routes.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-rmath"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/tpapp/cl-rmath.git")))
+    :URL "https://github.com/tpapp/cl-rmath.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-rlimit"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/guicho271828/cl-rlimit.git")))
+    :URL "https://github.com/guicho271828/cl-rlimit.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-riff"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/RobBlackwell/cl-riff.git")))
+    :URL "https://github.com/RobBlackwell/cl-riff.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-rfc2047"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/eugeneia/cl-rfc2047.git")))
+    :URL "https://github.com/eugeneia/cl-rfc2047.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-rethinkdb"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/orthecreedence/cl-rethinkdb.git")))
+    :URL "https://github.com/orthecreedence/cl-rethinkdb.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-registry"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/eslick/cl-registry.git")))
+    :URL "https://github.com/eslick/cl-registry.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-reexport"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/takagi/cl-reexport.git")))
+    :URL "https://github.com/takagi/cl-reexport.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-redis"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/vseloved/cl-redis.git")))
+    :URL "https://github.com/vseloved/cl-redis.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-reddit"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/jperson/cl-reddit.git")))
+    :URL "https://github.com/jperson/cl-reddit.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-recaptcha"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/madnificent/cl-recaptcha/")))
+    :URL "https://github.com/madnificent/cl-recaptcha/")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-readline"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/mrkkrp/cl-readline.git")))
+    :URL "https://github.com/mrkkrp/cl-readline.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-read-macro-tokens"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/mabragor/cl-read-macro-tokens.git")))
+    :URL "https://github.com/mabragor/cl-read-macro-tokens.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-rdfxml"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/tayloj/cl-rdfxml.git")))
+    :URL "https://github.com/tayloj/cl-rdfxml.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-rcfiles"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "https://www.lrde.epita.fr/~didier/software/lisp/cl-rcfiles.tar.gz")))
+    :URL "https://www.lrde.epita.fr/~didier/software/lisp/cl-rcfiles.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-random"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/tpapp/cl-random.git")))
+    :URL "https://github.com/tpapp/cl-random.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-randist"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/lvaruzza/cl-randist.git")))
+    :URL "https://github.com/lvaruzza/cl-randist.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-rabbit"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/lokedhs/cl-rabbit.git")))
+    :URL "https://github.com/lokedhs/cl-rabbit.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-quickcheck"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/mcandre/cl-quickcheck")))
+    :URL "https://github.com/mcandre/cl-quickcheck")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-quakeinfo"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/e40/cl-quakeinfo.git")))
+    :URL "https://github.com/e40/cl-quakeinfo.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-qrencode"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/jnjcc/cl-qrencode.git")))
+    :URL "https://github.com/jnjcc/cl-qrencode.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-qprint"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/eugeneia/cl-qprint.git")))
+    :URL "https://github.com/eugeneia/cl-qprint.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-python"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/metawilm/cl-python.git")))
+    :URL "https://github.com/metawilm/cl-python.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-pslib"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/cage2/cl-pslib.git")))
+    :URL "https://github.com/cage2/cl-pslib.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-pslib-barcode"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/cage2/cl-pslib-barcode.git")))
+    :URL "https://github.com/cage2/cl-pslib-barcode.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-protobufs"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://gitlab.common-lisp.net/qitab/cl-protobufs.git")))
+    :URL "https://gitlab.common-lisp.net/qitab/cl-protobufs.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-prolog"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/keithj/cl-prolog.git")))
+    :URL "https://github.com/keithj/cl-prolog.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-project"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/fukamachi/cl-project.git")))
+    :URL "https://github.com/fukamachi/cl-project.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-proj"
-    :VC "mercurial"
-    :LOCATIONS (("latest" . "https://bitbucket.org/vityok/cl-proj")))
+    :URL "https://bitbucket.org/vityok/cl-proj")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-prime-maker"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/nakrakiiya/cl-prime-maker.git")))
+    :URL "https://github.com/nakrakiiya/cl-prime-maker.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-primality"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/smithzvk/cl-primality.git")))
+    :URL "https://github.com/smithzvk/cl-primality.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-prevalence"
-    :VC "mercurial"
-    :LOCATIONS (("latest" . "http://bitbucket.org/skypher/cl-prevalence")))
+    :URL "http://bitbucket.org/skypher/cl-prevalence")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-ppcre"
-    :VC "http"
-    :LOCATIONS (("latest" . "http://weitz.de/files/cl-ppcre.tar.gz")))
+    :URL "http://weitz.de/files/cl-ppcre.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-portaudio"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/filonenko-mikhail/cl-portaudio.git")))
+    :URL "https://github.com/filonenko-mikhail/cl-portaudio.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-popen"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/archimag/cl-popen")))
+    :URL "https://github.com/archimag/cl-popen")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-pop"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/cl-pop/cl-pop.tar.gz")))
+    :URL "http://common-lisp.net/project/cl-pop/cl-pop.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-poker-eval"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/jperson/cl-poker-eval.git")))
+    :URL "https://github.com/jperson/cl-poker-eval.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-png"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://www.ljosa.com/~ljosa/software/cl-png/download/cl-png-0.6.tar.gz")))
+    :URL "http://www.ljosa.com/~ljosa/software/cl-png/download/cl-png-0.6.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-ply"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/takagi/cl-ply.git")))
+    :URL "https://github.com/takagi/cl-ply.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-plumbing"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/smithzvk/cl-plumbing.git")))
+    :URL "https://github.com/smithzvk/cl-plumbing.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-plplot"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/HazenBabcock/cl-plplot.git")))
+    :URL "https://github.com/HazenBabcock/cl-plplot.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-photo"
-    :VC "kmr-git"
-    :LOCATIONS (("latest" . "cl-photo")))
+    :URL "cl-photo")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-permutation"
-    :VC "mercurial"
-    :LOCATIONS (("latest"
-                 . "https://bitbucket.org/tarballs_are_good/cl-permutation")))
+    :URL "https://bitbucket.org/tarballs_are_good/cl-permutation")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-performance-tuning-helper"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/ichimal/cl-performance-tuning-helper.git")))
+    :URL "https://github.com/ichimal/cl-performance-tuning-helper.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-pdf"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/mbattyani/cl-pdf.git")))
+    :URL "https://github.com/mbattyani/cl-pdf.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-paypal"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/standin000/cl-paypal.git")))
+    :URL "https://github.com/standin000/cl-paypal.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-paymill"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/a0-prw/cl-paymill.git")))
+    :URL "https://github.com/a0-prw/cl-paymill.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-pattern"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/arielnetworks/cl-pattern.git")))
+    :URL "https://github.com/arielnetworks/cl-pattern.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-pattern"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/arielnetworks/cl-pattern.git")))
+    :URL "https://github.com/arielnetworks/cl-pattern.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-pass"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/eudoxia0/cl-pass.git")))
+    :URL "https://github.com/eudoxia0/cl-pass.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-parser-combinators"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/Ramarren/cl-parser-combinators.git")))
+    :URL "https://github.com/Ramarren/cl-parser-combinators.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-parallel"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/nahiluhmot/cl-parallel.git")))
+    :URL "https://github.com/nahiluhmot/cl-parallel.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-package-locks"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/elliottjohnson/cl-package-locks.git")))
+    :URL "https://github.com/elliottjohnson/cl-package-locks.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-org-mode"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://gitlab.common-lisp.net/cl-org-mode/cl-org-mode.git")))
+    :URL "https://gitlab.common-lisp.net/cl-org-mode/cl-org-mode.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-opsresearch"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/OpsResearchLLC/cl-opsresearch.git")))
+    :URL "https://github.com/OpsResearchLLC/cl-opsresearch.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-openstack-client"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/stackforge/cl-openstack-client.git")))
+    :URL "https://github.com/stackforge/cl-openstack-client.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-openid"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/cl-openid/cl-openid.git")))
+    :URL "https://github.com/cl-openid/cl-openid.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-opengl"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/3b/cl-opengl.git")))
+    :URL "https://github.com/3b/cl-opengl.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-openal"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/zkat/cl-openal.git")))
+    :URL "https://github.com/zkat/cl-openal.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-op"
-    :VC "svn"
-    :LOCATIONS (("latest" . "http://cl-op.googlecode.com/svn/trunk/")))
+    :URL "http://cl-op.googlecode.com/svn/trunk/")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-one-time-passwords"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/bhyde/cl-one-time-passwords.git")))
+    :URL "https://github.com/bhyde/cl-one-time-passwords.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-olefs"
-    :VC "git"
-    :LOCATIONS (("latest" . "http://logand.com/git/cl-olefs.git")))
+    :URL "http://logand.com/git/cl-olefs.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-odesk"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/dym/cl-odesk.git")))
+    :URL "https://github.com/dym/cl-odesk.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-oauth"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/skypher/cl-oauth.git")))
+    :URL "https://github.com/skypher/cl-oauth.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-nxt"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/woudshoo/cl-nxt.git")))
+    :URL "https://github.com/woudshoo/cl-nxt.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-num-utils"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/tpapp/cl-num-utils.git")))
+    :URL "https://github.com/tpapp/cl-num-utils.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-ntriples"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://iweb.dl.sourceforge.net/project/cl-ntriples/cl-ntriples-latest.tgz")))
+    :URL "http://iweb.dl.sourceforge.net/project/cl-ntriples/cl-ntriples-latest.tgz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-netstrings"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/RyanHope/cl-netstrings.git")))
+    :URL "https://github.com/RyanHope/cl-netstrings.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-netstring-plus"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/mtstickney/cl-netstring-plus.git")))
+    :URL "https://github.com/mtstickney/cl-netstring-plus.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-neo4j"
-    :VC "branched-git"
-    :LOCATIONS (("latest" . "https://github.com/kraison/cl-neo4j.git release")))
+    :URL "https://github.com/kraison/cl-neo4j.git release")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-ncurses"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/cl-ncurses/files/cl-ncurses_latest-version.tgz")))
+    :URL "http://common-lisp.net/project/cl-ncurses/files/cl-ncurses_latest-version.tgz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-mysql"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/hackinghat/cl-mysql.git")))
+    :URL "https://github.com/hackinghat/cl-mysql.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-mw"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/psilord/cl-mw.git")))
+    :URL "https://github.com/psilord/cl-mw.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-mustache"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/kanru/cl-mustache.git")))
+    :URL "https://github.com/kanru/cl-mustache.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-murmurhash"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/ruricolist/cl-murmurhash.git")))
+    :URL "https://github.com/ruricolist/cl-murmurhash.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-muproc"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://www.common-lisp.net/project/cl-muproc/cl-muproc.tar.gz")))
+    :URL "http://www.common-lisp.net/project/cl-muproc/cl-muproc.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-mtgnet"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/mtstickney/cl-mtgnet.git")))
+    :URL "https://github.com/mtstickney/cl-mtgnet.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-mssql"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/archimag/cl-mssql.git")))
+    :URL "https://github.com/archimag/cl-mssql.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-mpi"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/angavrilov/cl-mpi.git")))
+    :URL "https://github.com/angavrilov/cl-mpi.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-mop"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Inaimathi/cl-mop.git")))
+    :URL "https://github.com/Inaimathi/cl-mop.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-mongo"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/fons/cl-mongo.git")))
+    :URL "https://github.com/fons/cl-mongo.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-mongo-id"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/orthecreedence/cl-mongo-id.git")))
+    :URL "https://github.com/orthecreedence/cl-mongo-id.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-moneris"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/vsedach/cl-moneris.git")))
+    :URL "https://github.com/vsedach/cl-moneris.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-monad-macros"
-    :VC "svn"
-    :LOCATIONS (("latest"
-                 . "svn://common-lisp.net/project/cl-monad-macros/svn/trunk")))
+    :URL "svn://common-lisp.net/project/cl-monad-macros/svn/trunk")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-modlisp"
-    :VC "kmr-git"
-    :LOCATIONS (("latest" . "cl-modlisp")))
+    :URL "cl-modlisp")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-mock"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Ferada/cl-mock.git")))
+    :URL "https://github.com/Ferada/cl-mock.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-mlep"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/fzalkow/cl-mlep.git")))
+    :URL "https://github.com/fzalkow/cl-mlep.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-mime"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/hanshuebner/cl-mime.git")))
+    :URL "https://github.com/hanshuebner/cl-mime.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-migrations"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/cl-migrations/cl-migrations-latest.tgz")))
+    :URL "http://common-lisp.net/project/cl-migrations/cl-migrations-latest.tgz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-messagepack"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/mbrezu/cl-messagepack.git")))
+    :URL "https://github.com/mbrezu/cl-messagepack.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-memcached"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/quasi/cl-memcached.git")))
+    :URL "https://github.com/quasi/cl-memcached.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-mediawiki"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/AccelerationNet/cl-mediawiki.git")))
+    :URL "https://github.com/AccelerationNet/cl-mediawiki.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-mechanize"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/joachifm/cl-mechanize.git")))
+    :URL "https://github.com/joachifm/cl-mechanize.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-mathstats"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/gwkkwg/cl-mathstats.git")))
+    :URL "https://github.com/gwkkwg/cl-mathstats.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-match"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/tonyg/cl-match.git")))
+    :URL "https://github.com/tonyg/cl-match.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-marshal"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/wlbr/cl-marshal.git")))
+    :URL "https://github.com/wlbr/cl-marshal.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-markup"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/arielnetworks/cl-markup.git")))
+    :URL "https://github.com/arielnetworks/cl-markup.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-marklogic"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/OpsResearchLLC/cl-marklogic.git")))
+    :URL "https://github.com/OpsResearchLLC/cl-marklogic.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-markdown"
-    :VC "darcs"
-    :LOCATIONS (("latest" . "http://common-lisp.net/project/cl-markdown")))
+    :URL "http://common-lisp.net/project/cl-markdown")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-m4"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/e-user/cl-m4.git")))
+    :URL "https://github.com/e-user/cl-m4.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-ltsv"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/taksatou/cl-ltsv.git")))
+    :URL "https://github.com/taksatou/cl-ltsv.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-logic"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/jollheef/cl-logic.git")))
+    :URL "https://github.com/jollheef/cl-logic.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-log"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://www.nicklevine.org/cl-log/cl-log-latest.tar.gz")))
+    :URL "http://www.nicklevine.org/cl-log/cl-log-latest.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-locatives"
-    :VC "mercurial"
-    :LOCATIONS (("latest"
-                 . "https://bitbucket.org/tarballs_are_good/cl-locatives")))
+    :URL "https://bitbucket.org/tarballs_are_good/cl-locatives")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-locale"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/arielnetworks/cl-locale.git")))
+    :URL "https://github.com/arielnetworks/cl-locale.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-llvm"
-    :VC "branched-git"
-    :LOCATIONS (("latest" . "https://github.com/sellout/CL-LLVM.git llvm-2.9")))
+    :URL "https://github.com/sellout/CL-LLVM.git llvm-2.9")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-llvm"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/sellout/CL-LLVM.git")))
+    :URL "https://github.com/sellout/CL-LLVM.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-libyaml"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/eudoxia0/cl-libyaml.git")))
+    :URL "https://github.com/eudoxia0/cl-libyaml.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-libxml2"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/archimag/cl-libxml2.git")))
+    :URL "https://github.com/archimag/cl-libxml2.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-libuv"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/orthecreedence/cl-libuv.git")))
+    :URL "https://github.com/orthecreedence/cl-libuv.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-libusb"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/soemraws/cl-libusb.git")))
+    :URL "https://github.com/soemraws/cl-libusb.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-libsvm"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/melisgl/cl-libsvm.git")))
+    :URL "https://github.com/melisgl/cl-libsvm.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-libssh2"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/alxchk/cl-libssh2.git")))
+    :URL "https://github.com/alxchk/cl-libssh2.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-libpuzzle"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/pocket7878/cl-libpuzzle.git")))
+    :URL "https://github.com/pocket7878/cl-libpuzzle.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-libevent2"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/orthecreedence/cl-libevent2.git")))
+    :URL "https://github.com/orthecreedence/cl-libevent2.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-liballegro"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/resttime/cl-liballegro.git")))
+    :URL "https://github.com/resttime/cl-liballegro.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-lexer"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/starseeker/cl-lexer.git")))
+    :URL "https://github.com/starseeker/cl-lexer.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-lex"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://cl-lex.googlecode.com/files/cl-lex_1.1.2.tar.gz")))
+    :URL "http://cl-lex.googlecode.com/files/cl-lex_1.1.2.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-ledger"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/jwiegley/cl-ledger.git")))
+    :URL "https://github.com/jwiegley/cl-ledger.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-launch"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "https://common-lisp.net/project/xcvb/cl-launch/cl-launch.tar.gz")))
+    :URL "https://common-lisp.net/project/xcvb/cl-launch/cl-launch.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-lastfm"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "https://github.com/nlamirault/cl-lastfm/archive/0.2.1.tar.gz")))
+    :URL "https://github.com/nlamirault/cl-lastfm/archive/0.2.1.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-larval"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/mabragor/cl-larval.git")))
+    :URL "https://github.com/mabragor/cl-larval.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-langutils"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/eslick/cl-langutils.git")))
+    :URL "https://github.com/eslick/cl-langutils.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-l10n"
-    :VC "darcs"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/cl-l10n/repos/cl-l10n")))
+    :URL "http://common-lisp.net/project/cl-l10n/repos/cl-l10n")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-l10n-cldr"
-    :VC "darcs"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/cl-l10n/repos/cl-l10n-cldr/")))
+    :URL "http://common-lisp.net/project/cl-l10n/repos/cl-l10n-cldr/")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-kyoto-cabinet"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/kraison/cl-kyoto-cabinet.git")))
+    :URL "https://github.com/kraison/cl-kyoto-cabinet.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-kanren-trs"
-    :VC "svn"
-    :LOCATIONS (("latest"
-                 . "svn://common-lisp.net/project/cl-kanren-trs/svn")))
+    :URL "svn://common-lisp.net/project/cl-kanren-trs/svn")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-junit-xml"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/AccelerationNet/cl-junit-xml.git")))
+    :URL "https://github.com/AccelerationNet/cl-junit-xml.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-json"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/hankhero/cl-json.git")))
+    :URL "https://github.com/hankhero/cl-json.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-json-template"
-    :VC "mercurial"
-    :LOCATIONS (("latest"
-                 . "http://matthias.benkard.de/code/cl-json-template/")))
+    :URL "http://matthias.benkard.de/code/cl-json-template/")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-jpl-util"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://www.thoughtcrime.us/software/cl-jpl-util/cl-jpl-util-0.4.tar.gz")))
+    :URL "http://www.thoughtcrime.us/software/cl-jpl-util/cl-jpl-util-0.4.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-jpeg"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/sharplispers/cl-jpeg.git")))
+    :URL "https://github.com/sharplispers/cl-jpeg.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-ixf"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/dimitri/cl-ixf.git")))
+    :URL "https://github.com/dimitri/cl-ixf.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-isaac"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/thephoeron/cl-isaac.git")))
+    :URL "https://github.com/thephoeron/cl-isaac.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-irregsexp"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://gitlab.common-lisp.net/cl-irregsexp/cl-irregsexp.git")))
+    :URL "https://gitlab.common-lisp.net/cl-irregsexp/cl-irregsexp.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-irc"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/cl-irc/releases/cl-irc_latest.tar.gz")))
+    :URL "http://common-lisp.net/project/cl-irc/releases/cl-irc_latest.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-interpol"
-    :VC "http"
-    :LOCATIONS (("latest" . "http://weitz.de/files/cl-interpol.tar.gz")))
+    :URL "http://weitz.de/files/cl-interpol.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-intbytes"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/EuAndreh/cl-intbytes.git")))
+    :URL "https://github.com/EuAndreh/cl-intbytes.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-inotify"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Ferada/cl-inotify.git")))
+    :URL "https://github.com/Ferada/cl-inotify.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-influxdb"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/mmaul/cl-influxdb.git")))
+    :URL "https://github.com/mmaul/cl-influxdb.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-inflector"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/AccelerationNet/cl-inflector.git")))
+    :URL "https://github.com/AccelerationNet/cl-inflector.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-indeterminism"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/mabragor/cl-indeterminism.git")))
+    :URL "https://github.com/mabragor/cl-indeterminism.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-iconv"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/quek/cl-iconv.git")))
+    :URL "https://github.com/quek/cl-iconv.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-i18n"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/cage2/cl-i18n.git")))
+    :URL "https://github.com/cage2/cl-i18n.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-hue"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/jd/cl-hue.git")))
+    :URL "https://github.com/jd/cl-hue.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-html5-parser"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/copyleft/cl-html5-parser.git")))
+    :URL "https://github.com/copyleft/cl-html5-parser.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-html-parse"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/gwkkwg/cl-html-parse.git")))
+    :URL "https://github.com/gwkkwg/cl-html-parse.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-html-diff"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/wiseman/cl-html-diff.git")))
+    :URL "https://github.com/wiseman/cl-html-diff.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-heredoc"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/e-user/cl-heredoc.git")))
+    :URL "https://github.com/e-user/cl-heredoc.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-heap"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/cl-heap/releases/cl-heap_latest.tar.gz")))
+    :URL "http://common-lisp.net/project/cl-heap/releases/cl-heap_latest.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-hash-util"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/orthecreedence/cl-hash-util.git")))
+    :URL "https://github.com/orthecreedence/cl-hash-util.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-hamt"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/danshapero/cl-hamt.git")))
+    :URL "https://github.com/danshapero/cl-hamt.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-haml"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Unspeakable/cl-haml.git")))
+    :URL "https://github.com/Unspeakable/cl-haml.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-gtk2"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/dmitryvk/cl-gtk2.git")))
+    :URL "https://github.com/dmitryvk/cl-gtk2.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-gss"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/lokedhs/cl-gss.git")))
+    :URL "https://github.com/lokedhs/cl-gss.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-growl"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/nklein/cl-growl.git")))
+    :URL "https://github.com/nklein/cl-growl.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-groupby"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/wlbr/cl-groupby.git")))
+    :URL "https://github.com/wlbr/cl-groupby.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-gravatar"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/sellout/cl-gravatar.git")))
+    :URL "https://github.com/sellout/cl-gravatar.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-graph"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/gwkkwg/cl-graph")))
+    :URL "https://github.com/gwkkwg/cl-graph")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-grace"
-    :VC "mercurial"
-    :LOCATIONS (("latest" . "https://bitbucket.org/pdo/cl-grace")))
+    :URL "https://bitbucket.org/pdo/cl-grace")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-gpu"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/angavrilov/cl-gpu.git")))
+    :URL "https://github.com/angavrilov/cl-gpu.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-gobject-introspection"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/andy128k/cl-gobject-introspection.git")))
+    :URL "https://github.com/andy128k/cl-gobject-introspection.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-glfw3"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/AlexCharlton/cl-glfw3.git")))
+    :URL "https://github.com/AlexCharlton/cl-glfw3.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-glfw"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/jimrthy/cl-glfw.git")))
+    :URL "https://github.com/jimrthy/cl-glfw.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-github-v3"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/hanshuebner/cl-github-v3.git")))
+    :URL "https://github.com/hanshuebner/cl-github-v3.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-git"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/russell/cl-git.git")))
+    :URL "https://github.com/russell/cl-git.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-gists"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Rudolph-Miller/cl-gists.git")))
+    :URL "https://github.com/Rudolph-Miller/cl-gists.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-geometry"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Ramarren/cl-geometry.git")))
+    :URL "https://github.com/Ramarren/cl-geometry.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-geoip"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/dasuxullebt/cl-geoip.git")))
+    :URL "https://github.com/dasuxullebt/cl-geoip.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-geocode"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/e40/cl-geocode.git")))
+    :URL "https://github.com/e40/cl-geocode.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-geo"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://surejourney.com/software/cl-geo/cl-geo-0.2.tar.gz")))
+    :URL "http://surejourney.com/software/cl-geo/cl-geo-0.2.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-generic-arithmetic"
-    :VC "mercurial"
-    :LOCATIONS (("latest"
-                 . "https://bitbucket.org/tarballs_are_good/cl-generic-arithmetic")))
+    :URL "https://bitbucket.org/tarballs_are_good/cl-generic-arithmetic")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-general-accumulator"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/tlikonen/cl-general-accumulator.git")))
+    :URL "https://github.com/tlikonen/cl-general-accumulator.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-gene-searcher"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/TheDarkTrumpet/cl-gene-searcher.git")))
+    :URL "https://github.com/TheDarkTrumpet/cl-gene-searcher.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-gendoc"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/rpav/cl-gendoc.git")))
+    :URL "https://github.com/rpav/cl-gendoc.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-gearman"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/taksatou/cl-gearman.git")))
+    :URL "https://github.com/taksatou/cl-gearman.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-gdata"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/lokedhs/cl-gdata.git")))
+    :URL "https://github.com/lokedhs/cl-gdata.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-gd"
-    :VC "http"
-    :LOCATIONS (("latest" . "http://weitz.de/files/cl-gd.tar.gz")))
+    :URL "http://weitz.de/files/cl-gd.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-gap-buffer"
-    :VC "mercurial"
-    :LOCATIONS (("latest"
-                 . "https://bitbucket.org/tarballs_are_good/cl-gap-buffer")))
+    :URL "https://bitbucket.org/tarballs_are_good/cl-gap-buffer")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-gambol"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/wmannis/cl-gambol")))
+    :URL "https://github.com/wmannis/cl-gambol")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-fuse"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/fb08af68/cl-fuse.git")))
+    :URL "https://github.com/fb08af68/cl-fuse.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-fuse-meta-fs"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/fb08af68/cl-fuse-meta-fs.git")))
+    :URL "https://github.com/fb08af68/cl-fuse-meta-fs.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-ftp"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://web.kepibu.org/code/lisp/cl-ftp/cl-ftp.tar.gz")))
+    :URL "http://web.kepibu.org/code/lisp/cl-ftp/cl-ftp.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-fsnotify"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/howeyc/cl-fsnotify.git")))
+    :URL "https://github.com/howeyc/cl-fsnotify.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-freetype2"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/rpav/cl-freetype2.git")))
+    :URL "https://github.com/rpav/cl-freetype2.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-fluidinfo"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/hdurer/cl-fluiddb.git")))
+    :URL "https://github.com/hdurer/cl-fluiddb.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-flowd"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/mmaul/cl-flowd.git")))
+    :URL "https://github.com/mmaul/cl-flowd.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-fgraph"
-    :VC "mercurial"
-    :LOCATIONS (("latest"
-                 . "https://bitbucket.org/thomas_bartscher/cl-fgraph")))
+    :URL "https://bitbucket.org/thomas_bartscher/cl-fgraph")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-fbclient"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/klimenko-serj/cl-fbclient.git")))
+    :URL "https://github.com/klimenko-serj/cl-fbclient.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-fastcgi"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/KDr2/cl-fastcgi.git")))
+    :URL "https://github.com/KDr2/cl-fastcgi.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-fam"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/7max/cl-fam.git")))
+    :URL "https://github.com/7max/cl-fam.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-fad"
-    :VC "http"
-    :LOCATIONS (("latest" . "http://weitz.de/files/cl-fad.tar.gz")))
+    :URL "http://weitz.de/files/cl-fad.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-factoring"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/smithzvk/cl-factoring.git")))
+    :URL "https://github.com/smithzvk/cl-factoring.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-ewkb"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/filonenko-mikhail/cl-ewkb.git")))
+    :URL "https://github.com/filonenko-mikhail/cl-ewkb.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-ev"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/sbryant/cl-ev.git")))
+    :URL "https://github.com/sbryant/cl-ev.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-erlang-term"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/flambard/cl-erlang-term.git")))
+    :URL "https://github.com/flambard/cl-erlang-term.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-epoch"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/mcandre/cl-epoch.git")))
+    :URL "https://github.com/mcandre/cl-epoch.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-epmd"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/flambard/cl-epmd.git")))
+    :URL "https://github.com/flambard/cl-epmd.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-enumeration"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://gitlab.common-lisp.net/cl-enumeration/enumerations.git")))
+    :URL "https://gitlab.common-lisp.net/cl-enumeration/enumerations.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-enchant"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/tlikonen/cl-enchant.git")))
+    :URL "https://github.com/tlikonen/cl-enchant.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-emb"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/38a938c2/cl-emb.git")))
+    :URL "https://github.com/38a938c2/cl-emb.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-emacs-if"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/7max/cl-emacs-if.git")))
+    :URL "https://github.com/7max/cl-emacs-if.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-durian"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/GordianNaught/cl-durian.git")))
+    :URL "https://github.com/GordianNaught/cl-durian.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-dsl"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/mabragor/cl-dsl.git")))
+    :URL "https://github.com/mabragor/cl-dsl.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-dropbox"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/jsmpereira/cl-dropbox.git")))
+    :URL "https://github.com/jsmpereira/cl-dropbox.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-dot"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/michaelw/cl-dot.git")))
+    :URL "https://github.com/michaelw/cl-dot.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-docutils"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/willijar/cl-docutils.git")))
+    :URL "https://github.com/willijar/cl-docutils.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-disque"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/CodyReichert/cl-disque.git")))
+    :URL "https://github.com/CodyReichert/cl-disque.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-difflib"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/wiseman/cl-difflib.git")))
+    :URL "https://github.com/wiseman/cl-difflib.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-diceware"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/billstclair/cl-diceware.git")))
+    :URL "https://github.com/billstclair/cl-diceware.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-devil"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/zkat/cl-devil.git")))
+    :URL "https://github.com/zkat/cl-devil.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-decimals"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/tlikonen/cl-decimals")))
+    :URL "https://github.com/tlikonen/cl-decimals")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-dbi"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/fukamachi/cl-dbi.git")))
+    :URL "https://github.com/fukamachi/cl-dbi.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-db3"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/dimitri/cl-db3.git")))
+    :URL "https://github.com/dimitri/cl-db3.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-date-time-parser"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/tkych/cl-date-time-parser.git")))
+    :URL "https://github.com/tkych/cl-date-time-parser.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-data-frame"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/tpapp/cl-data-frame.git")))
+    :URL "https://github.com/tpapp/cl-data-frame.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-data-format-validation"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/willijar/cl-data-format-validation.git")))
+    :URL "https://github.com/willijar/cl-data-format-validation.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-custom-hash-table"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/metawilm/cl-custom-hash-table.git")))
+    :URL "https://github.com/metawilm/cl-custom-hash-table.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-curlex"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/mabragor/cl-curlex.git")))
+    :URL "https://github.com/mabragor/cl-curlex.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-ctrnn"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://www.pvv.ntnu.no/~oyvinht/static/OSS/cl-ctrnn/cl-ctrnn_latest.tar.gz")))
+    :URL "http://www.pvv.ntnu.no/~oyvinht/static/OSS/cl-ctrnn/cl-ctrnn_latest.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-csv"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/AccelerationNet/cl-csv.git")))
+    :URL "https://github.com/AccelerationNet/cl-csv.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-css"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Inaimathi/cl-css.git")))
+    :URL "https://github.com/Inaimathi/cl-css.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-crypt"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/renard/cl-crypt.git")))
+    :URL "https://github.com/renard/cl-crypt.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-cron"
-    :VC "mercurial"
-    :LOCATIONS (("latest" . "https://bitbucket.org/mackram/cl-cron")))
+    :URL "https://bitbucket.org/mackram/cl-cron")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-cron"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://www.trailoflight.net/downloads/cl-cron.tar.gz")))
+    :URL "http://www.trailoflight.net/downloads/cl-cron.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-creditcard"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/AccelerationNet/cl-creditcard.git")))
+    :URL "https://github.com/AccelerationNet/cl-creditcard.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-crc64"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/RobBlackwell/cl-crc64.git")))
+    :URL "https://github.com/RobBlackwell/cl-crc64.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-coveralls"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/fukamachi/cl-coveralls.git")))
+    :URL "https://github.com/fukamachi/cl-coveralls.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-coroutine"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/takagi/cl-coroutine.git")))
+    :URL "https://github.com/takagi/cl-coroutine.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-cookie"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/fukamachi/cl-cookie.git")))
+    :URL "https://github.com/fukamachi/cl-cookie.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-containers"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/gwkkwg/cl-containers.git")))
+    :URL "https://github.com/gwkkwg/cl-containers.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-cont"
-    :VC "darcs"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/cl-cont/darcs/cl-cont")))
+    :URL "http://common-lisp.net/project/cl-cont/darcs/cl-cont")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-conspack"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/conspack/cl-conspack.git")))
+    :URL "https://github.com/conspack/cl-conspack.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-colors"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/tpapp/cl-colors.git")))
+    :URL "https://github.com/tpapp/cl-colors.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-closure-template"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/archimag/cl-closure-template.git")))
+    :URL "https://github.com/archimag/cl-closure-template.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-clon"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "https://www.lrde.epita.fr/~didier/software/lisp/clon/latest.tar.gz")))
+    :URL "https://www.lrde.epita.fr/~didier/software/lisp/clon/latest.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-cli"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/renard/cl-cli.git")))
+    :URL "https://github.com/renard/cl-cli.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-cli-parser"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://gitlab.common-lisp.net/cl-cli-parser/cl-cli-parser.git")))
+    :URL "https://gitlab.common-lisp.net/cl-cli-parser/cl-cli-parser.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-cheshire-cat"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/mentel/cl-cheshire-cat.git")))
+    :URL "https://github.com/mentel/cl-cheshire-cat.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-charms"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/HiTECNOLOGYs/cl-charms.git")))
+    :URL "https://github.com/HiTECNOLOGYs/cl-charms.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-cffi-gtk"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/crategus/cl-cffi-gtk.git")))
+    :URL "https://github.com/crategus/cl-cffi-gtk.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-case-control"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/ichimal/cl-case-control.git")))
+    :URL "https://github.com/ichimal/cl-case-control.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-cairo2"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/rpav/cl-cairo2.git")))
+    :URL "https://github.com/rpav/cl-cairo2.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-ca"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/lukasepple/cl-ca.git")))
+    :URL "https://github.com/lukasepple/cl-ca.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-buchberger"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/jmbr/cl-buchberger.git")))
+    :URL "https://github.com/jmbr/cl-buchberger.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-btree"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://iweb.dl.sourceforge.net/project/cl-btree/cl-btree-0.5.tgz")))
+    :URL "http://iweb.dl.sourceforge.net/project/cl-btree/cl-btree-0.5.tgz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-bson"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/EuAndreh/cl-bson.git")))
+    :URL "https://github.com/EuAndreh/cl-bson.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-bplustree"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/ebobby/cl-bplustree.git")))
+    :URL "https://github.com/ebobby/cl-bplustree.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-bloom"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/ruricolist/cl-bloom.git")))
+    :URL "https://github.com/ruricolist/cl-bloom.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-blapack"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/blindglobe/cl-blapack.git")))
+    :URL "https://github.com/blindglobe/cl-blapack.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-binary-file"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://iweb.dl.sourceforge.net/project/cl-binary-file/cl-binary-file-0.4.tgz")))
+    :URL "http://iweb.dl.sourceforge.net/project/cl-binary-file/cl-binary-file-0.4.tgz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-bibtex"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/mkoeppe/cl-bibtex.git")))
+    :URL "https://github.com/mkoeppe/cl-bibtex.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-bert"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/flambard/cl-bert.git")))
+    :URL "https://github.com/flambard/cl-bert.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-bencode"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/nja/cl-bencode.git")))
+    :URL "https://github.com/nja/cl-bencode.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-beanstalk"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/antifuchs/cl-beanstalk.git")))
+    :URL "https://github.com/antifuchs/cl-beanstalk.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-bayesnet"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/lhope/cl-bayesnet.git")))
+    :URL "https://github.com/lhope/cl-bayesnet.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-base64"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://beta.quicklisp.org/archive/cl-base64/2015-09-23/cl-base64-20150923-git.tgz")))
+    :URL "http://beta.quicklisp.org/archive/cl-base64/2015-09-23/cl-base64-20150923-git.tgz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-base58"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/eudoxia0/cl-base58.git")))
+    :URL "https://github.com/eudoxia0/cl-base58.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-base32"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/hargettp/cl-base32.git")))
+    :URL "https://github.com/hargettp/cl-base32.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-bacteria"
-    :VC "mercurial"
-    :LOCATIONS (("latest" . "http://code.google.com/p/cl-bacteria")))
+    :URL "http://code.google.com/p/cl-bacteria")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-azure"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/RobBlackwell/cl-azure.git")))
+    :URL "https://github.com/RobBlackwell/cl-azure.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-autowrap"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/rpav/cl-autowrap.git")))
+    :URL "https://github.com/rpav/cl-autowrap.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-autorepo"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/billstclair/cl-autorepo.git")))
+    :URL "https://github.com/billstclair/cl-autorepo.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-async"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/orthecreedence/cl-async.git")))
+    :URL "https://github.com/orthecreedence/cl-async.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-async-future"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/orthecreedence/cl-async-future.git")))
+    :URL "https://github.com/orthecreedence/cl-async-future.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-arrows"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/nightfly19/cl-arrows.git")))
+    :URL "https://github.com/nightfly19/cl-arrows.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-arff-parser"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/pieterw/cl-arff-parser.git")))
+    :URL "https://github.com/pieterw/cl-arff-parser.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-apple-plist"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/RobBlackwell/cl-apple-plist.git")))
+    :URL "https://github.com/RobBlackwell/cl-apple-plist.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-ansi-text"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/pnathan/cl-ansi-text.git")))
+    :URL "https://github.com/pnathan/cl-ansi-text.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-ansi-term"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/mrkkrp/cl-ansi-term.git")))
+    :URL "https://github.com/mrkkrp/cl-ansi-term.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-anonfun"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/arielnetworks/cl-anonfun.git")))
+    :URL "https://github.com/arielnetworks/cl-anonfun.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-annot"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/m2ym/cl-annot.git")))
+    :URL "https://github.com/m2ym/cl-annot.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-annot-prove"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/Rudolph-Miller/cl-annot-prove.git")))
+    :URL "https://github.com/Rudolph-Miller/cl-annot-prove.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-ana"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/ghollisjr/cl-ana.git")))
+    :URL "https://github.com/ghollisjr/cl-ana.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-algebraic-data-type"
-    :VC "mercurial"
-    :LOCATIONS (("latest"
-                 . "https://bitbucket.org/tarballs_are_good/cl-algebraic-data-type")))
+    :URL "https://bitbucket.org/tarballs_are_good/cl-algebraic-data-type")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-acronyms"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/isoraqathedh/cl-acronyms.git")))
+    :URL "https://github.com/isoraqathedh/cl-acronyms.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-abstract-classes"
-    :VC "mercurial"
-    :LOCATIONS (("latest"
-                 . "https://bitbucket.org/eeeickythump/cl-abstract-classes")))
+    :URL "https://bitbucket.org/eeeickythump/cl-abstract-classes")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-abnf"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/dimitri/cl-abnf.git")))
+    :URL "https://github.com/dimitri/cl-abnf.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl-6502"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/redline6561/cl-6502.git")))
+    :URL "https://github.com/redline6561/cl-6502.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cl+ssl"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/cl-plus-ssl/cl-plus-ssl.git")))
+    :URL "https://github.com/cl-plus-ssl/cl-plus-ssl.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "city-hash"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/brown/city-hash.git")))
+    :URL "https://github.com/brown/city-hash.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "circular-streams"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/fukamachi/circular-streams.git")))
+    :URL "https://github.com/fukamachi/circular-streams.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "chunga"
-    :VC "http"
-    :LOCATIONS (("latest" . "http://weitz.de/files/chunga.tar.gz")))
+    :URL "http://weitz.de/files/chunga.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "chtml-matcher"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/eslick/chtml-matcher.git")))
+    :URL "https://github.com/eslick/chtml-matcher.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "chronicity"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/chaitanyagupta/chronicity.git")))
+    :URL "https://github.com/chaitanyagupta/chronicity.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "chrome-native-messaging"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/Ralt/chrome-native-messaging.git")))
+    :URL "https://github.com/Ralt/chrome-native-messaging.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "chirp"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Shinmera/chirp.git")))
+    :URL "https://github.com/Shinmera/chirp.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "chipz"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/froydnj/chipz.git")))
+    :URL "https://github.com/froydnj/chipz.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "chillax"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/zkat/chillax.git")))
+    :URL "https://github.com/zkat/chillax.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "chemical-compounds"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/chemboy/chemical-compounds-latest.tar.gz")))
+    :URL "http://common-lisp.net/project/chemboy/chemical-compounds-latest.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "checkl"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/rpav/CheckL.git")))
+    :URL "https://github.com/rpav/CheckL.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "check-it"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/DalekBaldwin/check-it.git")))
+    :URL "https://github.com/DalekBaldwin/check-it.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cheat-js"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/mbrezu/Cheat-JS.git")))
+    :URL "https://github.com/mbrezu/Cheat-JS.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "chanl"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/zkat/chanl.git")))
+    :URL "https://github.com/zkat/chanl.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "changed-stream"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/WarrenWilkinson/changed-stream.git")))
+    :URL "https://github.com/WarrenWilkinson/changed-stream.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cffi"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "https://common-lisp.net/project/cffi/releases/cffi_latest.tar.gz")))
+    :URL "https://common-lisp.net/project/cffi/releases/cffi_latest.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cffi-objects"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Kalimehtar/cffi-objects.git")))
+    :URL "https://github.com/Kalimehtar/cffi-objects.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cerberus"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/fjames86/cerberus.git")))
+    :URL "https://github.com/fjames86/cerberus.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "ceramic"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/ceramic/ceramic.git")))
+    :URL "https://github.com/ceramic/ceramic.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cells"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/kennytilton/cells.git")))
+    :URL "https://github.com/kennytilton/cells.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cells-gtk3"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Ramarren/cells-gtk3.git")))
+    :URL "https://github.com/Ramarren/cells-gtk3.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "caveman"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/fukamachi/caveman.git")))
+    :URL "https://github.com/fukamachi/caveman.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cartesian-product-switch"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://tarballs.hexstreamsoft.com/libraries/latest/cartesian-product-switch_latest.tar.gz")))
+    :URL "http://tarballs.hexstreamsoft.com/libraries/latest/cartesian-product-switch_latest.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "carrier"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/orthecreedence/carrier.git")))
+    :URL "https://github.com/orthecreedence/carrier.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "caramel"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/pocket7878/Caramel.git")))
+    :URL "https://github.com/pocket7878/Caramel.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "cambl"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/jwiegley/cambl.git")))
+    :URL "https://github.com/jwiegley/cambl.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "calispel"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://www.thoughtcrime.us/software/calispel/calispel-0.1.tar.gz")))
+    :URL "http://www.thoughtcrime.us/software/calispel/calispel-0.1.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "bytecurry.mocks"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/bytecurry/bytecurry.mocks.git")))
+    :URL "https://github.com/bytecurry/bytecurry.mocks.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "bytecurry.asdf-ext"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/bytecurry/bytecurry.asdf-ext.git")))
+    :URL "https://github.com/bytecurry/bytecurry.asdf-ext.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "burgled-batteries"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/pinterface/burgled-batteries.git")))
+    :URL "https://github.com/pinterface/burgled-batteries.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "burgled-batteries.syntax"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/mmontone/burgled-batteries.syntax.git")))
+    :URL "https://github.com/mmontone/burgled-batteries.syntax.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "buildnode"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/AccelerationNet/buildnode.git")))
+    :URL "https://github.com/AccelerationNet/buildnode.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "buildapp"
-    :VC "http"
-    :LOCATIONS (("latest" . "http://www.xach.com/lisp/buildapp.tgz")))
+    :URL "http://www.xach.com/lisp/buildapp.tgz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "buffalo"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/fhuttner/buffalo.git")))
+    :URL "https://github.com/fhuttner/buffalo.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "bubble-operator-upwards"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://tarballs.hexstreamsoft.com/libraries/latest/bubble-operator-upwards_latest.tar.gz")))
+    :URL "http://tarballs.hexstreamsoft.com/libraries/latest/bubble-operator-upwards_latest.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "btrie"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/peterhil/btrie.git")))
+    :URL "https://github.com/peterhil/btrie.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "bt-semaphore"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/rmoritz/bt-semaphore.git")))
+    :URL "https://github.com/rmoritz/bt-semaphore.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "bourbaki"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://juhaarpi.users.paivola.fi/bourbaki/bourbaki.tar.gz")))
+    :URL "http://juhaarpi.users.paivola.fi/bourbaki/bourbaki.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "bordeaux-threads"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "https://common-lisp.net/project/bordeaux-threads/releases/bordeaux-threads.tar.gz")))
+    :URL "https://common-lisp.net/project/bordeaux-threads/releases/bordeaux-threads.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "bordeaux-fft"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://vintage-digital.com/hefner/software/bordeaux-fft/bordeaux-fft-current.tar.gz")))
+    :URL "http://vintage-digital.com/hefner/software/bordeaux-fft/bordeaux-fft-current.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "blackthorn-engine"
-    :VC "mercurial"
-    :LOCATIONS (("latest"
-                 . "https://bitbucket.org/elliottslaughter/blackthorn-engine")))
+    :URL "https://bitbucket.org/elliottslaughter/blackthorn-engine")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "blackbird"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/orthecreedence/blackbird.git")))
+    :URL "https://github.com/orthecreedence/blackbird.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "black-tie"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/aerique/black-tie.git")))
+    :URL "https://github.com/aerique/black-tie.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "bknr-web"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/hanshuebner/bknr-web.git")))
+    :URL "https://github.com/hanshuebner/bknr-web.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "bknr-datastore"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/hanshuebner/bknr-datastore.git")))
+    :URL "https://github.com/hanshuebner/bknr-datastore.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "bk-tree"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/vy/bk-tree.git")))
+    :URL "https://github.com/vy/bk-tree.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "bitfield-schema"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://bitbucket.org/swizard/bitfield-schema.git")))
+    :URL "https://bitbucket.org/swizard/bitfield-schema.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "bit-smasher"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/thephoeron/bit-smasher.git")))
+    :URL "https://github.com/thephoeron/bit-smasher.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "birch"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/jorams/birch.git")))
+    :URL "https://github.com/jorams/birch.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "binomial-heap"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/vy/binomial-heap.git")))
+    :URL "https://github.com/vy/binomial-heap.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "binge"
-    :VC "http-bz2"
-    :LOCATIONS (("latest"
-                 . "http://wcp.sdf-eu.org/software/binge-latest.tbz")))
+    :URL "http://wcp.sdf-eu.org/software/binge-latest.tbz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "binfix"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/vcerovski/binfix.git")))
+    :URL "https://github.com/vcerovski/binfix.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "binascii"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/froydnj/binascii.git")))
+    :URL "https://github.com/froydnj/binascii.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "binary-types"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Ferada/binary-types")))
+    :URL "https://github.com/Ferada/binary-types")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "big-string"
-    :VC "mercurial"
-    :LOCATIONS (("latest"
-                 . "https://bitbucket.org/tarballs_are_good/big-string")))
+    :URL "https://bitbucket.org/tarballs_are_good/big-string")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "beirc"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://gitlab.common-lisp.net/beirc/beirc.git")))
+    :URL "https://gitlab.common-lisp.net/beirc/beirc.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "basic-binary-ipc"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/markcox80/basic-binary-ipc.git")))
+    :URL "https://github.com/markcox80/basic-binary-ipc.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "backports"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/esessoms/backports.git")))
+    :URL "https://github.com/esessoms/backports.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "babel"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/cl-babel/babel.git")))
+    :URL "https://github.com/cl-babel/babel.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "ayah-captcha"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/aarvid/ayah-captcha.git")))
+    :URL "https://github.com/aarvid/ayah-captcha.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "aws-sign4"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/copyleft/aws-sign4.git")))
+    :URL "https://github.com/copyleft/aws-sign4.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "avatar-api"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/eudoxia0/avatar-api.git")))
+    :URL "https://github.com/eudoxia0/avatar-api.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "atdoc"
-    :VC "git"
-    :LOCATIONS (("latest" . "http://www.lichteblau.com/git/atdoc.git")))
+    :URL "http://www.lichteblau.com/git/atdoc.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "asteroids"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/stacksmith/asteroids.git")))
+    :URL "https://github.com/stacksmith/asteroids.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "asn.1"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/cl-net-snmp/release/asn.1_latest.tar.gz")))
+    :URL "http://common-lisp.net/project/cl-net-snmp/release/asn.1_latest.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "asdf-system-connections"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/gwkkwg/asdf-system-connections.git")))
+    :URL "https://github.com/gwkkwg/asdf-system-connections.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "asdf-project-helper"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/ichimal/asdf-project-helper.git")))
+    :URL "https://github.com/ichimal/asdf-project-helper.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "asdf-package-system"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://gitlab.common-lisp.net/asdf/asdf-package-system.git")))
+    :URL "https://gitlab.common-lisp.net/asdf/asdf-package-system.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "asdf-linguist"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/eudoxia0/asdf-linguist.git")))
+    :URL "https://github.com/eudoxia0/asdf-linguist.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "asdf-flv"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "https://www.lrde.epita.fr/~didier/software/lisp/asdf-flv/attic/asdf-flv-1.0.tar.gz")))
+    :URL "https://www.lrde.epita.fr/~didier/software/lisp/asdf-flv/attic/asdf-flv-1.0.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "asdf-finalizers"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://gitlab.common-lisp.net/asdf/asdf-finalizers.git")))
+    :URL "https://gitlab.common-lisp.net/asdf/asdf-finalizers.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "asdf-encodings"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://gitlab.common-lisp.net/asdf/asdf-encodings.git")))
+    :URL "https://gitlab.common-lisp.net/asdf/asdf-encodings.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "asdf-dependency-grovel"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://gitlab.common-lisp.net/xcvb/asdf-dependency-grovel.git")))
+    :URL "https://gitlab.common-lisp.net/xcvb/asdf-dependency-grovel.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "arrow-macros"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/hipeta/arrow-macros.git")))
+    :URL "https://github.com/hipeta/arrow-macros.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "array-utils"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Shinmera/array-utils.git")))
+    :URL "https://github.com/Shinmera/array-utils.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "array-operations"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/tpapp/array-operations.git")))
+    :URL "https://github.com/tpapp/array-operations.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "arnesi"
-    :VC "darcs"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/bese/repos/arnesi_dev/")))
+    :URL "http://common-lisp.net/project/bese/repos/arnesi_dev/")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "archive"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/froydnj/archive")))
+    :URL "https://github.com/froydnj/archive")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "architecture.service-provider"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/scymtym/architecture.service-provider.git")))
+    :URL "https://github.com/scymtym/architecture.service-provider.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "architecture.hooks"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/scymtym/architecture.hooks.git")))
+    :URL "https://github.com/scymtym/architecture.hooks.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "arc-compat"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/g000001/arc-compat.git")))
+    :URL "https://github.com/g000001/arc-compat.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "apply-argv"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/pve1/apply-argv.git")))
+    :URL "https://github.com/pve1/apply-argv.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "antik"
-    :VC "branched-git"
-    :LOCATIONS (("latest"
-                 . "https://gitlab.common-lisp.net/antik/antik.git master")))
+    :URL "https://gitlab.common-lisp.net/antik/antik.git master")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "anaphoric-variants"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://tarballs.hexstreamsoft.com/libraries/latest/anaphoric-variants_latest.tar.gz")))
+    :URL "http://tarballs.hexstreamsoft.com/libraries/latest/anaphoric-variants_latest.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "anaphora"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/anaphora/files/anaphora-latest.tar.gz")))
+    :URL "http://common-lisp.net/project/anaphora/files/anaphora-latest.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "amazon-ecs"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/gonzojive/amazon-ecs.git")))
+    :URL "https://github.com/gonzojive/amazon-ecs.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "algebraic-data-library"
-    :VC "mercurial"
-    :LOCATIONS (("latest"
-                 . "https://bitbucket.org/tarballs_are_good/algebraic-data-library")))
+    :URL "https://bitbucket.org/tarballs_are_good/algebraic-data-library")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "alexandria"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://gitlab.common-lisp.net/alexandria/alexandria.git")))
+    :URL "https://gitlab.common-lisp.net/alexandria/alexandria.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "adw-charting"
-    :VC "http"
-    :LOCATIONS (("latest"
-                 . "http://common-lisp.net/project/adw-charting/adw-charting.tar.gz")))
+    :URL "http://common-lisp.net/project/adw-charting/adw-charting.tar.gz")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "advanced-readtable"
-    :VC "git"
-    :LOCATIONS (("latest"
-                 . "https://github.com/Kalimehtar/advanced-readtable.git")))
+    :URL "https://github.com/Kalimehtar/advanced-readtable.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "access"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/AccelerationNet/access.git")))
+    :URL "https://github.com/AccelerationNet/access.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "able"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/dherring/able.git")))
+    :URL "https://github.com/dherring/able.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "3d-vectors"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/Shinmera/3d-vectors.git")))
+    :URL "https://github.com/Shinmera/3d-vectors.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "3bmd"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/3b/3bmd.git")))
+    :URL "https://github.com/3b/3bmd.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "3b-swf"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/3b/3b-swf.git")))
+    :URL "https://github.com/3b/3b-swf.git")
  #S(QI.MANIFEST::MANIFEST-PACKAGE
     :NAME "1am"
-    :VC "git"
-    :LOCATIONS (("latest" . "https://github.com/lmj/1am.git"))))
+    :URL "https://github.com/lmj/1am.git"))

--- a/src/manifest.lisp
+++ b/src/manifest.lisp
@@ -3,7 +3,6 @@
   (:use :cl)
   (:export :manifest-package
            :make-manifest-package
-           :create-download-strategy
            :manifest-get-by-name))
 (in-package :qi.manifest)
 
@@ -22,13 +21,7 @@
 manifest. `locations' is an ADT that holds an alist to allow searching for
 a specific version of a package."
   name
-  vc
-  (locations 'cons))
-
-(adt:defdata version-location
-  "An algebraic data-type for storing a '(version . location) alist
-inside of a manifest-package."
-  (ver-loc cons))
+  url)
 
 
 (defun manifest-load ()
@@ -40,26 +33,6 @@ inside of a manifest-package."
          until (eq line 'eof)
          do (setf out (concatenate 'string out line)))
       (setf +manifest-packages+ (read-from-string out)))))
-
-
-(defun create-download-strategy (pack &optional (version "latest"))
-  "Takes a `manifest-package' data type, and returns download location
-for the specific version, and the download-strategy. Location is already
-wrapped in the ADT."
-  (let ((vc (manifest-package-vc pack))
-        (available (manifest-package-locations pack))
-        (loc))
-    (loop
-       for v/l in available
-       when (string= version (car v/l))
-       do
-         (setf loc (cdr v/l))
-         (format t "~%---> Resolved version ~S for ~S" (car v/l) (manifest-package-name pack)))
-    (cond ((string= "http" vc)
-           (values loc "tarball"))
-          ((string= "git" vc)
-           (values loc "git"))
-          (t (values loc "git")))))
 
 
 (defun manifest-get-by-name (sys-name)

--- a/src/util.lisp
+++ b/src/util.lisp
@@ -2,6 +2,7 @@
 (defpackage qi.util
   (:use :cl)
   (:export :asdf-system-path
+           :download-strategy
            :load-asdf-system
            :is-tar-url?
            :is-git-url?
@@ -38,6 +39,16 @@
   "Is <str> a github url."
   (ppcre:scan "^https://github.*" str))
 
+(defun download-strategy (url)
+  (cond ((is-tar-url? url)
+         :tarball)
+        ((or (is-git-url? url)
+             (is-gh-url? url))
+         :git)
+        ((is-hg-url? url)
+         :hg)
+        (t
+         (error "Could not determine download strategy for ~S" url))))
 
 (defun asdf-system-path (sys)
   "Find the pathname for a system, return NIL if it's not available."

--- a/t/integrations_test.lisp
+++ b/t/integrations_test.lisp
@@ -12,10 +12,9 @@
 ;; Tests that even if the tarball doesn't have the same name as what we expect, we still
 ;; sucessfully unpack it and load it.
 (let ((dep (qi::make-dependency :name "anaphora"
-                                :location (qi.packages::http "https://github.com/tokenrove/anaphora/tarball/master")
+                                :url "https://github.com/tokenrove/anaphora/tarball/master"
                                 :src-path (merge-pathnames tar-dir "anaphora-master.tar.gz")
-                                :sys-path (merge-pathnames tar-dir "anaphora-latest")
-                                :version "latest"))
+                                :sys-path (merge-pathnames tar-dir "anaphora-latest")))
       (tmpfile (merge-pathnames "anaphora-latest.tar.gz" (qi.paths:+dep-cache+))))
   (qi::bootstrap (qi.packages::dependency-name dep))
   (ensure-directories-exist (qi.paths:+dep-cache+))

--- a/t/manifest_test.lisp
+++ b/t/manifest_test.lisp
@@ -5,15 +5,12 @@
         :prove))
 (in-package :qi-manifest-util)
 
-(plan 4)
+(plan 3)
 
 (qi.manifest::manifest-load)
 
-(let ((strat (multiple-value-list
-              (qi.manifest:create-download-strategy
-               (qi.manifest:manifest-get-by-name "alexandria")))))
-  (is (first strat) "https://gitlab.common-lisp.net/alexandria/alexandria.git")
-  (is (last strat) '("git")))
+(let ((manifest (qi.manifest:manifest-get-by-name "alexandria")))
+  (is (qi.manifest::manifest-package-url manifest) "https://gitlab.common-lisp.net/alexandria/alexandria.git"))
 
 (is-type (qi.manifest:manifest-get-by-name "alexandria")
          'qi.manifest:manifest-package)

--- a/t/packages_test.lisp
+++ b/t/packages_test.lisp
@@ -19,8 +19,8 @@
   (ok "qi-git-test" (gethash "name" config))
   (let* ((p (car (gethash "packages" config)))
          (dep (qi::extract-dependency p)))
-    (is (qi.packages::dependency-download-strategy dep) "git")
-    (is (qi.packages::dependency-location dep)
+    (is (qi.packages::dependency-download-strategy dep) :git)
+    (is (qi.packages::dependency-url dep)
         "https://github.com/sharplispers/split-sequence.git")))
 
 (let ((config
@@ -29,8 +29,8 @@
   (ok "qi-hg-test" (gethash "name" config))
   (let* ((p (car (gethash "packages" config)))
          (dep (qi::extract-dependency p)))
-    (is (qi.packages::dependency-download-strategy dep) "hg")
-    (is (qi.packages::dependency-location dep)
+    (is (qi.packages::dependency-download-strategy dep) :hg)
+    (is (qi.packages::dependency-url dep)
         "https://bitbucket.org/tarballs_are_good/map-set")))
 
 (finalize)


### PR DESCRIPTION
This is a big one 😬 

The upshot is that manifests are simplified:
```lisp
 #S(QI.MANIFEST::MANIFEST-PACKAGE
    :NAME "f-underscore"
    :URL "https://github.com/nallen05/f-underscore.git")
```
Instead of a VC specified in the manifest, we use the same detection logic that we use for packages defined in `qi.yaml`.

I think this makes things clearer; if `download-strategy` isn't an attribute of a dependency we don't have to set it after the fact in `dispatch-dependency`.  The ADTs can go away too, which seems like a plus to me since I got confused by them.