### PR TITLE
fix `install-global`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.x86f
 *~
 .#*
+.dependencies
 /share
 t/resources/tar/*-latest/
 t/resources/tar/*-master/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: t
+
+t:
+	sbcl --noinform --non-interactive \
+	     --load init.lisp \
+	     --eval "(asdf:load-system :prove)" \
+	     --eval "(prove:run :qi-test)"

--- a/README.org
+++ b/README.org
@@ -240,7 +240,15 @@ for a full list).
    that I'd like to see done. Make a PR or start a conversation if
    there's anything you'd like to see.
 
-   With any PR - add your name to the =Contributors= section below.
+   If you can, add new tests to cover the changes you make!  You can
+   run tests locally with Roswell (=run-prove=) or with =make t=:
+
+   #+BEGIN_SRC sh
+   bin/qi -i prove
+   make t
+   #+END_SRC
+
+   With any PR, add your name to the =Contributors= section below.
 
 
 ** Contributors

--- a/docs/qi.html
+++ b/docs/qi.html
@@ -673,7 +673,18 @@ there's anything you'd like to see.
 </p>
 
 <p>
-With any PR - add your name to the <code>Contributors</code> section below.
+If you can, add new tests to cover the changes you make!  You can
+run tests locally with Roswell (<code>run-prove</code>) or with <code>make t</code>:
+</p>
+
+<div class="org-src-container">
+<pre class="src src-sh">bin/qi -i prove
+make t
+</pre>
+</div>
+
+<p>
+With any PR, add your name to the <code>Contributors</code> section below.
 </p>
 </div>
 </div>

--- a/qi-test.asd
+++ b/qi-test.asd
@@ -20,6 +20,7 @@
                                      (:test-file "manifest_test")
                                      (:test-file "packages_test")
                                      (:test-file "util_test")
+                                     (:test-file "qi_test")
                                      )))
   :description "Test system for qi"
 

--- a/src/qi.lisp
+++ b/src/qi.lisp
@@ -49,7 +49,8 @@
   (format t "~%Qi - A Common Lisp Package Manager")
   (format t "~%Version 0.1")
   (format t "~%Source: https://github.com/CodyReichert/qi")
-  (format t "~%Issues: https://github.com/CodyReichert/qi/issues"))
+  (format t "~%Issues: https://github.com/CodyReichert/qi/issues")
+  t)
 
 
 (defun install-global (system &optional (version "latest"))

--- a/t/qi_test.lisp
+++ b/t/qi_test.lisp
@@ -1,0 +1,12 @@
+(in-package :cl-user)
+(defpackage qi-test-qi
+  (:use :cl
+        :qi
+        :prove))
+(in-package :qi-test-packages)
+
+(plan 1)
+
+(ok (qi:install-global :yason))
+
+(finalize)

--- a/t/qi_test.lisp
+++ b/t/qi_test.lisp
@@ -5,7 +5,9 @@
         :prove))
 (in-package :qi-test-packages)
 
-(plan 1)
+(plan 2)
+
+(ok (qi:hello))
 
 (ok (qi:install-global :yason))
 

--- a/t/qi_test.lisp
+++ b/t/qi_test.lisp
@@ -5,9 +5,12 @@
         :prove))
 (in-package :qi-test-packages)
 
-(plan 2)
+(plan 3)
 
 (ok (qi:hello))
+
+(load "t/resources/project/test-project.asd")
+(ok (qi:install :test-project))
 
 (ok (qi:install-global :yason))
 

--- a/t/resources/project/qi.yaml
+++ b/t/resources/project/qi.yaml
@@ -1,0 +1,3 @@
+name: test-project
+packages:
+  - name: yason

--- a/t/resources/project/test-project.asd
+++ b/t/resources/project/test-project.asd
@@ -1,0 +1,7 @@
+(defpackage #:test-project
+  (:use #:cl)
+  (:export #:main))
+
+(asdf:defsystem #:test-project
+  :description "Test"
+  :depends-on (#:yason))


### PR DESCRIPTION
I was so focused on the local installation scenario that I didn't notice I broke `install-global`.