### PR TITLE
remove src-path and improve sys-path

### DIFF
--- a/src/packages.lisp
+++ b/src/packages.lisp
@@ -329,7 +329,7 @@ local sys-path."
 
 
 (defun set-sys-path (dep)
-  "Update an a dependency's src-path and sys-path."
+  "Update an a dependency's sys-path."
   (let* ((strat (dependency-download-strategy dep))
          (sys-path (fad:merge-pathnames-as-directory
                     (qi.paths:package-dir)

--- a/src/packages.lisp
+++ b/src/packages.lisp
@@ -330,11 +330,27 @@ local sys-path."
 
 (defun set-sys-path (dep)
   "Update an a dependency's src-path and sys-path."
-  (let ((sys-path (fad:merge-pathnames-as-directory
-                   (qi.paths:package-dir)
-                   (concatenate 'string
-                                (dependency-name dep) "-"
-                                (dependency-version dep) "/"))))
+  (let* ((strat (dependency-download-strategy dep))
+         (sys-path (fad:merge-pathnames-as-directory
+                    (qi.paths:package-dir)
+                    (concatenate 'string
+                                 (dependency-name dep)
+                                 ;; If it's a (versioned) tarball, add
+                                 ;; the version to the sys-path.  If
+                                 ;; it's a VCS source, then instead of
+                                 ;; the version use the download
+                                 ;; strategy as a suffix (since we'll
+                                 ;; want to update the existing
+                                 ;; repository when the version is
+                                 ;; changed, rather than fetching the
+                                 ;; entire repo to a new directory)
+                                 (if (eql strat :tarball)
+                                     (concatenate 'string "-" (dependency-version dep))
+                                     (concatenate 'string "--" (string-downcase (symbol-name strat))))
+                                 ;; Trailing slash to keep fad from
+                                 ;; thinking the last part is a
+                                 ;; filename and stripping it
+                                 "/"))))
     (setf (dependency-sys-path dep) sys-path)))
 
 

--- a/t/integrations_test.lisp
+++ b/t/integrations_test.lisp
@@ -13,7 +13,6 @@
 ;; sucessfully unpack it and load it.
 (let ((dep (qi::make-dependency :name "anaphora"
                                 :url "https://github.com/tokenrove/anaphora/tarball/master"
-                                :src-path (merge-pathnames tar-dir "anaphora-master.tar.gz")
                                 :sys-path (merge-pathnames tar-dir "anaphora-latest")))
       (tmpfile (merge-pathnames "anaphora-latest.tar.gz" (qi.paths:+dep-cache+))))
   (qi::bootstrap (qi.packages::dependency-name dep))


### PR DESCRIPTION
* `src-path` wasn't actually being used for anything, so the setter (previously `set-dependency-paths`, now `set-sys-path`) just sets `dependency-sys-path`.

* I previously moved the setter out of `download-tarball`, now it's been moved out of the git/hg clone functions as well.

* the dependency version is no longer used in the `sys-path` of git/hg dependencies, since version changes should just involve a fetch/reset, rather than a fresh clone to a new (versioned) directory.