### PR TITLE
remove sys-path as an attribute of dependency objects

### DIFF
--- a/src/qi.lisp
+++ b/src/qi.lisp
@@ -14,9 +14,9 @@
                 :dependency-name
                 :dependency-url
                 :dependency-version
-                :dependency-sys-path
                 :dispatch-dependency
                 :extract-dependency
+                :get-sys-path
                 :make-dependency
                 :make-manifest-dependency
                 :make-http-dependency
@@ -130,10 +130,11 @@ be in the CWD that specifies <project>'s dependencies."
   "Print information about the *qi-dependencies* list."
    (if (= 0 (length *qi-dependencies*))
        (format t "~%~%No dependencies installed!")
-     (let ((installed (remove-if-not #'dependency-sys-path *qi-dependencies*)))
-       (format t "~%~%~S dependencies installed:" (length installed))
+     (progn
+       (format t "~%~%~S dependencies installed:" (length *qi-dependencies*))
        (format t "~%~{   * ~A~%~}" (mapcar
                                     #'dependency-name
-                                    (sort installed (lambda (x y)
-                                                      (string-lessp (dependency-name x)
-                                                                    (dependency-name y)))))))))
+                                    (sort *qi-dependencies*
+                                          (lambda (x y)
+                                            (string-lessp (dependency-name x)
+                                                          (dependency-name y)))))))))

--- a/t/integrations_test.lisp
+++ b/t/integrations_test.lisp
@@ -12,8 +12,9 @@
 ;; Tests that even if the tarball doesn't have the same name as what we expect, we still
 ;; sucessfully unpack it and load it.
 (let ((dep (qi::make-dependency :name "anaphora"
-                                :url "https://github.com/tokenrove/anaphora/tarball/master"
-                                :sys-path (merge-pathnames tar-dir "anaphora-latest")))
+                                :version "latest"
+                                :download-strategy :tarball
+                                :url "https://github.com/tokenrove/anaphora/tarball/master"))
       (tmpfile (merge-pathnames "anaphora-latest.tar.gz" (qi.paths:+dep-cache+))))
   (qi::bootstrap (qi.packages::dependency-name dep))
   (ensure-directories-exist (qi.paths:+dep-cache+))
@@ -26,8 +27,7 @@
       (with-open-file (target tmpfile :direction :output :element-type '(unsigned-byte 8))
         (uiop:copy-stream-to-stream source target :element-type '(unsigned-byte 8)))))
 
-  (let ((out (qi.packages::unpack-tar dep)))
-    (ok (not (eql out (qi.packages:dependency-sys-path dep))) "Extracts tarball with different name.")
-    (ok (probe-file (qi.packages:dependency-sys-path dep)) "Extracts tarball and exists")))
+  (ok (qi.packages::unpack-tar dep))
+  (ok (probe-file (qi.packages:get-sys-path dep)) "Extracts tarball and exists"))
 
 (finalize)


### PR DESCRIPTION
It was an awkward attribute since it required being set after
initialization; instead just generate it as required with `get-sys-path'.