### PR TITLE
(minor) use format's pluralize directive ("dependenc[y/ies]")

### DIFF
--- a/src/qi.lisp
+++ b/src/qi.lisp
@@ -132,7 +132,7 @@ be in the CWD that specifies <project>'s dependencies."
    (if (= 0 (length *qi-dependencies*))
        (format t "~%~%No dependencies installed!")
      (progn
-       (format t "~%~%~S dependencies installed:" (length *qi-dependencies*))
+       (format t "~%~%~S dependenc~:@p installed:" (length *qi-dependencies*))
        (format t "~%~{   * ~A~%~}" (mapcar
                                     #'dependency-name
                                     (sort *qi-dependencies*


### PR DESCRIPTION
and voilà :)

http://gigamonkeys.com/book/a-few-format-recipes.html

> To help you generate messages with words properly pluralized, FORMAT provides the ~P directive, which simply emits an s unless the corresponding argument is 1.

```
(format nil "file~p" 1)  ==> "file"
(format nil "file~p" 10) ==> "files"
(format nil "file~p" 0)  ==> "files"
```

> Typically, however, you'll use ~P with the colon modifier, which causes it to reprocess the previous format argument.

```
(format nil "~r file~:p" 1)  ==> "one file"
(format nil "~r file~:p" 10) ==> "ten files"
(format nil "~r file~:p" 0)  ==> "zero files"
```

> With the at-sign modifier, which can be combined with the colon modifier, ~P emits either y or ies.

```
(format nil "~r famil~:@p" 1)  ==> "one family"
(format nil "~r famil~:@p" 10) ==> "ten families"
(format nil "~r famil~:@p" 0)  ==> "zero families"
```